### PR TITLE
feat(goals): add body check-ins + goal snapshot types

### DIFF
--- a/.github/prompts/phase4-goals.tasks.md
+++ b/.github/prompts/phase4-goals.tasks.md
@@ -2,9 +2,15 @@
 
 This task list turns the spec in `.github/prompts/plan-phase4GoalsSystemDetailedV2.prompt.md` into concrete work items.
 
+Workflow note:
+
+- One branch per GitHub issue (`{issue-id}-{lowercasetitle}`)
+- Make incremental changes freely, but do not commit until the issue is fully implemented and verified
+- After finishing an issue: commit + push, then wait for approval before opening a PR to `main`
+
 ## A) Database & Types
 
-- [ ] A1. Add goal-history fields to `nutrition_goals` table ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
+- [x] A1. Add goal-history fields to `nutrition_goals` table ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
   - Files: [src/server/db/schema.ts](src/server/db/schema.ts)
   - Add columns (per spec):
     - normalized inputs: `ageYears`, `sex`, `heightCm`, `weightKg`, `activityMultiplier`, `goalRateKgPerWeek`
@@ -13,15 +19,15 @@ This task list turns the spec in `.github/prompts/plan-phase4GoalsSystemDetailed
     - raw inputs: `inputUnitSystem`, `wizardInputs`
   - DoD: schema compiles; Drizzle types updated.
 
-- [ ] A2. Create and apply a Drizzle migration for the new columns ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
+- [x] A2. Create and apply a Drizzle migration for the new columns ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
   - Files: `drizzle/*.sql` (new)
   - DoD: `npm run db:push` (or migrate flow) succeeds locally.
 
-- [ ] A3. Update goal-related TypeScript types used by UI/queries ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
-  - Files: [src/types/food.ts](src/types/food.ts) (or wherever `NutritionGoals` / goal history types live)
+- [x] A3. Update goal-related TypeScript types used by UI/queries ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
+  - Files: [src/types/goals.ts](src/types/goals.ts)
   - DoD: goal history record type + wizard input types exist and are used in API/queries.
 
-- [ ] A4. Add body check-ins table for goal feedback history ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
+- [x] A4. Add body check-ins table for goal feedback history ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
   - Files: [src/server/db/schema.ts](src/server/db/schema.ts)
   - Create table `body_checkins` with:
     - required: `weightKg` (normalized), `checkInDate`, `userId`
@@ -30,7 +36,7 @@ This task list turns the spec in `.github/prompts/plan-phase4GoalsSystemDetailed
     - raw input: `inputUnitSystem`, `rawWeight`
   - DoD: types exported + relations (user/checkins, goal/checkins).
 
-- [ ] A5. Create and apply a Drizzle migration for `body_checkins` ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
+- [x] A5. Create and apply a Drizzle migration for `body_checkins` ([Issue #14](https://github.com/allanweber/nutrition-app/issues/14))
   - Files: `drizzle/*.sql` (new)
   - DoD: schema push/migrate succeeds locally.
 

--- a/drizzle/0001_greedy_captain_universe.sql
+++ b/drizzle/0001_greedy_captain_universe.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "body_checkins" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"goal_id" integer,
+	"check_in_date" timestamp NOT NULL,
+	"input_unit_system" varchar(10),
+	"weight_kg" numeric(10, 2) NOT NULL,
+	"raw_weight" jsonb,
+	"photos" jsonb,
+	"skinfolds_mm" jsonb,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "age_years" integer;--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "sex" varchar(20);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "height_cm" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "weight_kg" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "activity_multiplier" numeric(6, 3);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "goal_rate_kg_per_week" numeric(6, 3);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "macro_preset_id" varchar(50);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "protein_g_per_kg" numeric(6, 2);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "bmr_calories" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "tdee_calories" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "recommended_targets" jsonb;--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "was_manually_overridden" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "calorie_adjustment_strategy" varchar(30);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "input_unit_system" varchar(10);--> statement-breakpoint
+ALTER TABLE "nutrition_goals" ADD COLUMN "wizard_inputs" jsonb;--> statement-breakpoint
+ALTER TABLE "body_checkins" ADD CONSTRAINT "body_checkins_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "body_checkins" ADD CONSTRAINT "body_checkins_goal_id_nutrition_goals_id_fk" FOREIGN KEY ("goal_id") REFERENCES "public"."nutrition_goals"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "body_checkins_user_id_idx" ON "body_checkins" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "body_checkins_user_check_in_date_idx" ON "body_checkins" USING btree ("user_id","check_in_date");--> statement-breakpoint
+CREATE INDEX "body_checkins_goal_id_check_in_date_idx" ON "body_checkins" USING btree ("goal_id","check_in_date");--> statement-breakpoint
+CREATE INDEX "nutrition_goals_user_start_date_idx" ON "nutrition_goals" USING btree ("user_id","start_date");--> statement-breakpoint
+CREATE INDEX "nutrition_goals_user_end_date_idx" ON "nutrition_goals" USING btree ("user_id","end_date");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1819 @@
+{
+  "id": "bf4cc021-3cd3-4af8-b7f3-8156ebcfbbde",
+  "prevId": "7aadcd2e-d041-4487-9bfd-2d234617d4fc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_provider_id_idx": {
+          "name": "accounts_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.body_checkins": {
+      "name": "body_checkins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in_date": {
+          "name": "check_in_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_unit_system": {
+          "name": "input_unit_system",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_weight": {
+          "name": "raw_weight",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skinfolds_mm": {
+          "name": "skinfolds_mm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "body_checkins_user_id_idx": {
+          "name": "body_checkins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "body_checkins_user_check_in_date_idx": {
+          "name": "body_checkins_user_check_in_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_in_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "body_checkins_goal_id_check_in_date_idx": {
+          "name": "body_checkins_goal_id_check_in_date_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_in_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "body_checkins_user_id_user_id_fk": {
+          "name": "body_checkins_user_id_user_id_fk",
+          "tableFrom": "body_checkins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "body_checkins_goal_id_nutrition_goals_id_fk": {
+          "name": "body_checkins_goal_id_nutrition_goals_id_fk",
+          "tableFrom": "body_checkins",
+          "tableTo": "nutrition_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_plan_meals": {
+      "name": "diet_plan_meals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diet_plan_id": {
+          "name": "diet_plan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "meal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_plan_meals_diet_plan_id_idx": {
+          "name": "diet_plan_meals_diet_plan_id_idx",
+          "columns": [
+            {
+              "expression": "diet_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diet_plan_meals_food_id_idx": {
+          "name": "diet_plan_meals_food_id_idx",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_plan_meals_diet_plan_id_diet_plans_id_fk": {
+          "name": "diet_plan_meals_diet_plan_id_diet_plans_id_fk",
+          "tableFrom": "diet_plan_meals",
+          "tableTo": "diet_plans",
+          "columnsFrom": [
+            "diet_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_plan_meals_food_id_foods_id_fk": {
+          "name": "diet_plan_meals_food_id_foods_id_fk",
+          "tableFrom": "diet_plan_meals",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_plans": {
+      "name": "diet_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_calories": {
+          "name": "target_calories",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_protein": {
+          "name": "target_protein",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_carbs": {
+          "name": "target_carbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fat": {
+          "name": "target_fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_plans_user_id_idx": {
+          "name": "diet_plans_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diet_plans_client_id_idx": {
+          "name": "diet_plans_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_plans_user_id_user_id_fk": {
+          "name": "diet_plans_user_id_user_id_fk",
+          "tableFrom": "diet_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_plans_client_id_user_id_fk": {
+          "name": "diet_plans_client_id_user_id_fk",
+          "tableFrom": "diet_plans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.food_alt_measures": {
+      "name": "food_alt_measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_weight": {
+          "name": "serving_weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measure": {
+          "name": "measure",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "qty": {
+          "name": "qty",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "food_alt_measures_food_id_idx": {
+          "name": "food_alt_measures_food_id_idx",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_alt_measures_food_id_foods_id_fk": {
+          "name": "food_alt_measures_food_id_foods_id_fk",
+          "tableFrom": "food_alt_measures",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.food_logs": {
+      "name": "food_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "meal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "food_logs_user_id_idx": {
+          "name": "food_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "food_logs_food_id_idx": {
+          "name": "food_logs_food_id_idx",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "food_logs_consumed_at_idx": {
+          "name": "food_logs_consumed_at_idx",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_logs_user_id_user_id_fk": {
+          "name": "food_logs_user_id_user_id_fk",
+          "tableFrom": "food_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_logs_food_id_foods_id_fk": {
+          "name": "food_logs_food_id_foods_id_fk",
+          "tableFrom": "food_logs",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.food_photos": {
+      "name": "food_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highres": {
+          "name": "highres",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "food_photos_food_id_idx": {
+          "name": "food_photos_food_id_idx",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_photos_food_id_foods_id_fk": {
+          "name": "food_photos_food_id_foods_id_fk",
+          "tableFrom": "food_photos",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "food_photos_food_id_unique": {
+          "name": "food_photos_food_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "food_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foods": {
+      "name": "foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_custom'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_qty": {
+          "name": "serving_qty",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_weight_grams": {
+          "name": "serving_weight_grams",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_nutrients": {
+          "name": "full_nutrients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raw": {
+          "name": "is_raw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "foods_name_idx": {
+          "name": "foods_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foods_source_id_idx": {
+          "name": "foods_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foods_source_idx": {
+          "name": "foods_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foods_user_id_idx": {
+          "name": "foods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foods_is_custom_idx": {
+          "name": "foods_is_custom_idx",
+          "columns": [
+            {
+              "expression": "is_custom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_user_id_fk": {
+          "name": "foods_user_id_user_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nutrition_goals": {
+      "name": "nutrition_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_type": {
+          "name": "goal_type",
+          "type": "goal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age_years": {
+          "name": "age_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_cm": {
+          "name": "height_cm",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_multiplier": {
+          "name": "activity_multiplier",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_rate_kg_per_week": {
+          "name": "goal_rate_kg_per_week",
+          "type": "numeric(6, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "macro_preset_id": {
+          "name": "macro_preset_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protein_g_per_kg": {
+          "name": "protein_g_per_kg",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bmr_calories": {
+          "name": "bmr_calories",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tdee_calories": {
+          "name": "tdee_calories",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_targets": {
+          "name": "recommended_targets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_manually_overridden": {
+          "name": "was_manually_overridden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "calorie_adjustment_strategy": {
+          "name": "calorie_adjustment_strategy",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_unit_system": {
+          "name": "input_unit_system",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wizard_inputs": {
+          "name": "wizard_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_calories": {
+          "name": "target_calories",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_protein": {
+          "name": "target_protein",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_carbs": {
+          "name": "target_carbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fat": {
+          "name": "target_fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fiber": {
+          "name": "target_fiber",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_sodium": {
+          "name": "target_sodium",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_level": {
+          "name": "activity_level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nutrition_goals_user_id_idx": {
+          "name": "nutrition_goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nutrition_goals_user_start_date_idx": {
+          "name": "nutrition_goals_user_start_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nutrition_goals_user_end_date_idx": {
+          "name": "nutrition_goals_user_end_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nutrition_goals_user_id_user_id_fk": {
+          "name": "nutrition_goals_user_id_user_id_fk",
+          "tableFrom": "nutrition_goals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professional_verification": {
+      "name": "professional_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialization": {
+          "name": "specialization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "professional_verification_user_id_idx": {
+          "name": "professional_verification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "professional_verification_user_id_user_id_fk": {
+          "name": "professional_verification_user_id_user_id_fk",
+          "tableFrom": "professional_verification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_token_idx": {
+          "name": "sessions_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.goal_type": {
+      "name": "goal_type",
+      "schema": "public",
+      "values": [
+        "weight_loss",
+        "maintenance",
+        "weight_gain",
+        "muscle_gain",
+        "fat_loss",
+        "performance",
+        "general_health"
+      ]
+    },
+    "public.meal_type": {
+      "name": "meal_type",
+      "schema": "public",
+      "values": [
+        "breakfast",
+        "lunch",
+        "dinner",
+        "snack",
+        "morning_snack",
+        "afternoon_snack",
+        "evening_snack",
+        "pre_workout",
+        "post_workout",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "individual",
+        "professional",
+        "admin"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769063385372,
       "tag": "0000_cooing_maximus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1769156762557,
+      "tag": "0001_greedy_captain_universe",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/goals/page.tsx
+++ b/src/app/(dashboard)/goals/page.tsx
@@ -5,18 +5,17 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from '@/components/ui/select';
 import { useNutritionGoals } from '@/hooks/use-nutrition-goals';
+import type { ActivityLevel, GoalType } from '@/types/goals';
+import { useForm } from '@tanstack/react-form';
 import { Activity, Loader2, Target, TrendingUp } from 'lucide-react';
 import { useState } from 'react';
-import { useForm } from '@tanstack/react-form';
-import { goalsFormSchema, type GoalsFormData } from '@/lib/form-validation';
-import type { GoalType, ActivityLevel } from '@/types/food';
 
 export default function GoalsPage() {
   const { data: goals, isLoading, updateGoals } = useNutritionGoals();
@@ -96,19 +95,35 @@ export default function GoalsPage() {
                         <Label htmlFor="goalType">Goal Type</Label>
                         <Select
                           value={field.state.value}
-                          onValueChange={(value) => field.handleChange(value as GoalType)}
+                          onValueChange={(value) =>
+                            field.handleChange(value as GoalType)
+                          }
                         >
-                          <SelectTrigger className={`w-full ${field.state.meta.errors.length > 0 ? 'border-red-500' : ''}`}>
+                          <SelectTrigger
+                            className={`w-full ${field.state.meta.errors.length > 0 ? 'border-red-500' : ''}`}
+                          >
                             <SelectValue placeholder="Select your goal" />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="weight_loss">Weight Loss</SelectItem>
+                            <SelectItem value="weight_loss">
+                              Weight Loss
+                            </SelectItem>
                             <SelectItem value="fat_loss">Fat Loss</SelectItem>
-                            <SelectItem value="maintenance">Maintenance</SelectItem>
-                            <SelectItem value="weight_gain">Weight Gain</SelectItem>
-                            <SelectItem value="muscle_gain">Muscle Gain</SelectItem>
-                            <SelectItem value="performance">Performance</SelectItem>
-                            <SelectItem value="general_health">General Health</SelectItem>
+                            <SelectItem value="maintenance">
+                              Maintenance
+                            </SelectItem>
+                            <SelectItem value="weight_gain">
+                              Weight Gain
+                            </SelectItem>
+                            <SelectItem value="muscle_gain">
+                              Muscle Gain
+                            </SelectItem>
+                            <SelectItem value="performance">
+                              Performance
+                            </SelectItem>
+                            <SelectItem value="general_health">
+                              General Health
+                            </SelectItem>
                           </SelectContent>
                         </Select>
                         {field.state.meta.errors.length > 0 && (
@@ -127,17 +142,27 @@ export default function GoalsPage() {
                         <Label htmlFor="activityLevel">Activity Level</Label>
                         <Select
                           value={field.state.value}
-                          onValueChange={(value) => field.handleChange(value as ActivityLevel)}
+                          onValueChange={(value) =>
+                            field.handleChange(value as ActivityLevel)
+                          }
                         >
-                          <SelectTrigger className={`w-full ${field.state.meta.errors.length > 0 ? 'border-red-500' : ''}`}>
+                          <SelectTrigger
+                            className={`w-full ${field.state.meta.errors.length > 0 ? 'border-red-500' : ''}`}
+                          >
                             <SelectValue placeholder="Select activity level" />
                           </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="sedentary">Sedentary</SelectItem>
-                            <SelectItem value="light">Light Activity</SelectItem>
-                            <SelectItem value="moderate">Moderate Activity</SelectItem>
+                            <SelectItem value="light">
+                              Light Activity
+                            </SelectItem>
+                            <SelectItem value="moderate">
+                              Moderate Activity
+                            </SelectItem>
                             <SelectItem value="active">Very Active</SelectItem>
-                            <SelectItem value="extra_active">Extra Active</SelectItem>
+                            <SelectItem value="extra_active">
+                              Extra Active
+                            </SelectItem>
                           </SelectContent>
                         </Select>
                         {field.state.meta.errors.length > 0 && (
@@ -156,7 +181,10 @@ export default function GoalsPage() {
                       name="calories"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 500 || parseInt(value) > 15000
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 500 ||
+                          parseInt(value) > 15000
                             ? 'Calories must be between 500 and 15,000'
                             : undefined,
                       }}
@@ -171,7 +199,11 @@ export default function GoalsPage() {
                             placeholder="2000"
                             min="500"
                             max="15000"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">
@@ -186,7 +218,10 @@ export default function GoalsPage() {
                       name="protein"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 0 || parseInt(value) > 2000
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 0 ||
+                          parseInt(value) > 2000
                             ? 'Protein must be between 0 and 2,000g'
                             : undefined,
                       }}
@@ -201,7 +236,11 @@ export default function GoalsPage() {
                             placeholder="150"
                             min="0"
                             max="2000"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">
@@ -216,7 +255,10 @@ export default function GoalsPage() {
                       name="carbs"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 0 || parseInt(value) > 3000
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 0 ||
+                          parseInt(value) > 3000
                             ? 'Carbs must be between 0 and 3,000g'
                             : undefined,
                       }}
@@ -231,7 +273,11 @@ export default function GoalsPage() {
                             placeholder="250"
                             min="0"
                             max="3000"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">
@@ -246,7 +292,10 @@ export default function GoalsPage() {
                       name="fat"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 0 || parseInt(value) > 1000
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 0 ||
+                          parseInt(value) > 1000
                             ? 'Fat must be between 0 and 1,000g'
                             : undefined,
                       }}
@@ -261,7 +310,11 @@ export default function GoalsPage() {
                             placeholder="65"
                             min="0"
                             max="1000"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">
@@ -276,7 +329,10 @@ export default function GoalsPage() {
                       name="fiber"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 0 || parseInt(value) > 200
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 0 ||
+                          parseInt(value) > 200
                             ? 'Fiber must be between 0 and 200g'
                             : undefined,
                       }}
@@ -291,7 +347,11 @@ export default function GoalsPage() {
                             placeholder="25"
                             min="0"
                             max="200"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">
@@ -306,7 +366,10 @@ export default function GoalsPage() {
                       name="sodium"
                       validators={{
                         onChange: ({ value }) =>
-                          !value || isNaN(parseInt(value)) || parseInt(value) < 0 || parseInt(value) > 100000
+                          !value ||
+                          isNaN(parseInt(value)) ||
+                          parseInt(value) < 0 ||
+                          parseInt(value) > 100000
                             ? 'Sodium must be between 0 and 100,000mg'
                             : undefined,
                       }}
@@ -321,7 +384,11 @@ export default function GoalsPage() {
                             placeholder="2300"
                             min="0"
                             max="100000"
-                            className={field.state.meta.errors.length > 0 ? 'border-red-500' : ''}
+                            className={
+                              field.state.meta.errors.length > 0
+                                ? 'border-red-500'
+                                : ''
+                            }
                           />
                           {field.state.meta.errors.length > 0 && (
                             <div className="text-sm text-red-600 dark:text-red-400">

--- a/src/components/charts/daily-calories-chart.tsx
+++ b/src/components/charts/daily-calories-chart.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { DailyNutritionSummary, NutritionGoals } from '@/types/food';
+import { DailyNutritionSummary } from '@/types/food';
+import type { NutritionGoals } from '@/types/goals';
 import {
   CartesianGrid,
   Line,

--- a/src/hooks/use-nutrition-goals.ts
+++ b/src/hooks/use-nutrition-goals.ts
@@ -1,37 +1,37 @@
-import { useGoalsQuery, useUpdateGoalsMutation } from '@/queries/goals'
-import { NutritionGoals } from '@/types/food'
+import { useGoalsQuery, useUpdateGoalsMutation } from '@/queries/goals';
+import type { NutritionGoals } from '@/types/goals';
 
 export function useNutritionGoals() {
-  const query = useGoalsQuery()
-  const mutation = useUpdateGoalsMutation()
+  const query = useGoalsQuery();
+  const mutation = useUpdateGoalsMutation();
 
   const updateGoals = async (goals: NutritionGoals) => {
     try {
-      await mutation.mutateAsync(goals)
-      return { success: true, error: null }
+      await mutation.mutateAsync(goals);
+      return { success: true, error: null };
     } catch (error) {
       // Parse the API error message
-      let errorMessage = 'Failed to save goals'
+      let errorMessage = 'Failed to save goals';
       if (error instanceof Error) {
         // Try to extract the error message from the API response
         try {
-          const errorData = JSON.parse(error.message)
+          const errorData = JSON.parse(error.message);
           if (errorData.error) {
-            errorMessage = errorData.error
+            errorMessage = errorData.error;
           }
         } catch {
           // If not JSON, use the error message as-is
-          errorMessage = error.message
+          errorMessage = error.message;
         }
       }
-      return { success: false, error: errorMessage }
+      return { success: false, error: errorMessage };
     }
-  }
+  };
 
   return {
     data: query.data,
     isLoading: query.isLoading,
     error: query.error?.message || null,
     updateGoals,
-  }
+  };
 }

--- a/src/queries/goals.ts
+++ b/src/queries/goals.ts
@@ -1,24 +1,24 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { NutritionGoals } from '@/types/food'
+import type { NutritionGoals } from '@/types/goals';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-const GOALS_QUERY_KEY = ['goals']
+const GOALS_QUERY_KEY = ['goals'];
 
 export function useGoalsQuery() {
   return useQuery({
     queryKey: GOALS_QUERY_KEY,
     queryFn: async (): Promise<NutritionGoals> => {
-      const response = await fetch('/api/goals')
+      const response = await fetch('/api/goals');
       if (!response.ok) {
-        throw new Error('Failed to fetch goals')
+        throw new Error('Failed to fetch goals');
       }
-      const result = await response.json()
-      return result.goals
+      const result = await response.json();
+      return result.goals;
     },
-  })
+  });
 }
 
 export function useUpdateGoalsMutation() {
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (goals: NutritionGoals): Promise<NutritionGoals> => {
@@ -28,18 +28,18 @@ export function useUpdateGoalsMutation() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ goals }),
-      })
+      });
 
       if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || 'Failed to update goals')
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to update goals');
       }
 
-      const result = await response.json()
-      return result.goals
+      const result = await response.json();
+      return result.goals;
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(GOALS_QUERY_KEY, data)
+      queryClient.setQueryData(GOALS_QUERY_KEY, data);
     },
-  })
+  });
 }

--- a/src/stores/dashboard-store.ts
+++ b/src/stores/dashboard-store.ts
@@ -1,8 +1,5 @@
-import {
-  DailyNutritionSummary,
-  FoodLogEntry,
-  NutritionGoals,
-} from '@/types/food';
+import { DailyNutritionSummary, FoodLogEntry } from '@/types/food';
+import type { NutritionGoals } from '@/types/goals';
 import { create } from 'zustand';
 
 interface DashboardStore {

--- a/src/types/food.ts
+++ b/src/types/food.ts
@@ -76,33 +76,6 @@ export interface DailyNutritionSummary {
   foodCount: number;
 }
 
-export type GoalType =
-  | 'weight_loss'
-  | 'maintenance'
-  | 'weight_gain'
-  | 'muscle_gain'
-  | 'fat_loss'
-  | 'performance'
-  | 'general_health';
-
-export type ActivityLevel =
-  | 'sedentary'
-  | 'light'
-  | 'moderate'
-  | 'active'
-  | 'extra_active';
-
-export interface NutritionGoals {
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  fiber: number;
-  sodium: number;
-  goalType?: GoalType;
-  activityLevel?: ActivityLevel;
-}
-
 // Source-specific types
 export interface NutritionixFood {
   food_name: string;

--- a/src/types/goals.ts
+++ b/src/types/goals.ts
@@ -1,0 +1,90 @@
+export type UnitSystem = 'metric' | 'imperial';
+
+export type GoalType =
+  | 'weight_loss'
+  | 'maintenance'
+  | 'weight_gain'
+  | 'muscle_gain'
+  | 'fat_loss'
+  | 'performance'
+  | 'general_health';
+
+export type ActivityLevel =
+  | 'sedentary'
+  | 'light'
+  | 'moderate'
+  | 'active'
+  | 'extra_active';
+
+export interface NutritionGoals {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number;
+  sodium: number;
+  goalType?: GoalType;
+  activityLevel?: ActivityLevel;
+}
+
+export interface NutritionGoalWizardInputsSnapshot {
+  unitSystem: UnitSystem;
+  ageYears?: number;
+  sex?: string;
+  heightCm?: number;
+  weightKg?: number;
+  activityMultiplier?: number;
+  goalType?: GoalType;
+  goalRateKgPerWeek?: number | null;
+  macroPresetId?: string | null;
+  proteinGPerKg?: number | null;
+}
+
+export interface NutritionGoalHistoryRecord {
+  id: number;
+  goalType: GoalType;
+  activityLevel?: ActivityLevel | null;
+  startDate: string;
+  endDate?: string | null;
+  isActive: boolean;
+  createdAt: string;
+
+  targets: NutritionGoals;
+
+  // Wizard/calculation snapshot fields (optional while API is mid-migration)
+  ageYears?: number | null;
+  sex?: string | null;
+  heightCm?: number | null;
+  weightKg?: number | null;
+  activityMultiplier?: number | null;
+  goalRateKgPerWeek?: number | null;
+  macroPresetId?: string | null;
+  proteinGPerKg?: number | null;
+  bmrCalories?: number | null;
+  tdeeCalories?: number | null;
+  recommendedTargets?: Record<string, unknown> | null;
+  wasManuallyOverridden?: boolean | null;
+  calorieAdjustmentStrategy?: string | null;
+  inputUnitSystem?: UnitSystem | null;
+  wizardInputs?: Record<string, unknown> | null;
+}
+
+export type CheckinPhotoKey = 'front' | 'back' | 'left' | 'right';
+
+export type BodyCheckinPhotos = Partial<Record<CheckinPhotoKey, string>>;
+
+export interface BodyCheckin {
+  id: number;
+  userId: string;
+  goalId?: number | null;
+  checkInDate: string;
+
+  weightKg: number;
+  inputUnitSystem?: UnitSystem | null;
+  rawWeight?: Record<string, unknown> | null;
+
+  photos?: BodyCheckinPhotos | null;
+  skinfoldsMm?: Record<string, number> | null;
+  notes?: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
Closes #14.

## What
- Extends `nutrition_goals` to store wizard/calculation snapshot fields.
- Adds `body_checkins` table for periodic progress feedback (weight required; photos/skinfolds optional).
- Introduces dedicated goal-related TS types in `src/types/goals.ts` and migrates imports off `src/types/food.ts`.
- Updates Phase 4 tasks checklist for Issue #14.

## Testing
- `npx tsc -p tsconfig.json --noEmit`

## Notes
- Drizzle migration included for schema updates.