### PR TITLE
Refactor food log and goals handling to use UUIDs instead of integers

### DIFF
--- a/drizzle/0000_useful_random.sql
+++ b/drizzle/0000_useful_random.sql
@@ -19,9 +19,9 @@ CREATE TABLE "account" (
 );
 --> statement-breakpoint
 CREATE TABLE "body_checkins" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
-	"goal_id" integer,
+	"goal_id" uuid,
 	"check_in_date" timestamp NOT NULL,
 	"input_unit_system" varchar(10),
 	"weight_kg" numeric(10, 2) NOT NULL,
@@ -33,8 +33,8 @@ CREATE TABLE "body_checkins" (
 );
 --> statement-breakpoint
 CREATE TABLE "diet_plan_meal_groups" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"diet_plan_id" integer NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"diet_plan_id" uuid NOT NULL,
 	"meal_type" "meal_type" NOT NULL,
 	"day_of_week" integer,
 	"scheduled_at" timestamp,
@@ -43,9 +43,9 @@ CREATE TABLE "diet_plan_meal_groups" (
 );
 --> statement-breakpoint
 CREATE TABLE "diet_plan_meal_items" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"group_id" integer NOT NULL,
-	"food_id" integer,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"group_id" uuid NOT NULL,
+	"food_id" uuid,
 	"quantity" numeric(10, 2) NOT NULL,
 	"serving_unit" varchar(100),
 	"food_name" varchar(500) NOT NULL,
@@ -66,9 +66,9 @@ CREATE TABLE "diet_plan_meal_items" (
 );
 --> statement-breakpoint
 CREATE TABLE "diet_plan_meals" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"diet_plan_id" integer NOT NULL,
-	"food_id" integer NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"diet_plan_id" uuid NOT NULL,
+	"food_id" uuid NOT NULL,
 	"meal_type" "meal_type" NOT NULL,
 	"quantity" numeric(10, 2) NOT NULL,
 	"serving_unit" varchar(100),
@@ -77,7 +77,7 @@ CREATE TABLE "diet_plan_meals" (
 );
 --> statement-breakpoint
 CREATE TABLE "diet_plans" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"client_id" text NOT NULL,
 	"name" varchar(255) NOT NULL,
 	"description" text,
@@ -110,8 +110,8 @@ CREATE TABLE "email_verification_challenge" (
 );
 --> statement-breakpoint
 CREATE TABLE "food_alt_measures" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"food_id" integer NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"food_id" uuid NOT NULL,
 	"serving_weight" numeric(10, 2) NOT NULL,
 	"measure" varchar(100) NOT NULL,
 	"seq" integer DEFAULT 1,
@@ -120,9 +120,9 @@ CREATE TABLE "food_alt_measures" (
 );
 --> statement-breakpoint
 CREATE TABLE "food_log_items" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"meal_id" integer NOT NULL,
-	"food_id" integer,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"meal_id" uuid NOT NULL,
+	"food_id" uuid,
 	"quantity" numeric(10, 2) NOT NULL,
 	"serving_unit" varchar(100),
 	"food_name" varchar(500) NOT NULL,
@@ -143,18 +143,18 @@ CREATE TABLE "food_log_items" (
 );
 --> statement-breakpoint
 CREATE TABLE "food_log_meals" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
 	"meal_type" "meal_type" NOT NULL,
 	"consumed_at" timestamp NOT NULL,
-	"source_diet_plan_meal_group_id" integer,
+	"source_diet_plan_meal_group_id" uuid,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "food_photos" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"food_id" integer NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
+	"food_id" uuid NOT NULL,
 	"thumb" varchar(500),
 	"medium" varchar(500),
 	"highres" varchar(500),
@@ -163,7 +163,7 @@ CREATE TABLE "food_photos" (
 );
 --> statement-breakpoint
 CREATE TABLE "foods" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"source_id" varchar(100),
 	"source" varchar(100) DEFAULT 'user_custom' NOT NULL,
 	"name" varchar(500) NOT NULL,
@@ -188,7 +188,7 @@ CREATE TABLE "foods" (
 );
 --> statement-breakpoint
 CREATE TABLE "hydration_logs" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
 	"date" date NOT NULL,
 	"total_ml" integer DEFAULT 0 NOT NULL,
@@ -198,7 +198,7 @@ CREATE TABLE "hydration_logs" (
 );
 --> statement-breakpoint
 CREATE TABLE "nutrition_goals" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
 	"goal_type" "goal_type" NOT NULL,
 	"age_years" integer,

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "10d59d9e-6067-436b-b245-bd65f6cfc617",
+  "id": "07b5ebe6-064a-44e4-9888-b45c20e72b45",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -148,7 +148,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -160,7 +160,7 @@
         },
         "goal_id": {
           "name": "goal_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -313,13 +313,13 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "diet_plan_id": {
           "name": "diet_plan_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -428,19 +428,19 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "group_id": {
           "name": "group_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
         "food_id": {
           "name": "food_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -621,19 +621,19 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "diet_plan_id": {
           "name": "diet_plan_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
         "food_id": {
           "name": "food_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -742,7 +742,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -1017,13 +1017,13 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "food_id": {
           "name": "food_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -1105,19 +1105,19 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "meal_id": {
           "name": "meal_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
         "food_id": {
           "name": "food_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -1298,7 +1298,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -1323,7 +1323,7 @@
         },
         "source_diet_plan_meal_group_id": {
           "name": "source_diet_plan_meal_group_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -1447,13 +1447,13 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
         "food_id": {
           "name": "food_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -1535,7 +1535,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -1775,7 +1775,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -1872,7 +1872,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1774254367316,
-      "tag": "0000_dashing_killraven",
+      "when": 1774268959363,
+      "tag": "0000_useful_random",
       "breakpoints": true
     }
   ]

--- a/e2e/pages/food-log.page.ts
+++ b/e2e/pages/food-log.page.ts
@@ -64,7 +64,7 @@ export class FoodLogPage {
     await this.addFood();
   }
 
-  async deleteLog(logId: number) {
+  async deleteLog(logId: string) {
     const deleteButton = this.page.getByTestId(`delete-log-${logId}`);
     await deleteButton.click();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "recharts": "^3.6.0",
         "resend": "^6.8.0",
         "tailwind-merge": "^3.4.0",
+        "uuidv7": "^1.2.1",
         "zod": "^4.3.5",
         "zustand": "^5.0.10"
       },
@@ -10472,6 +10473,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv7": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.2.1.tgz",
+      "integrity": "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "recharts": "^3.6.0",
     "resend": "^6.8.0",
     "tailwind-merge": "^3.4.0",
+    "uuidv7": "^1.2.1",
     "zod": "^4.3.5",
     "zustand": "^5.0.10"
   },

--- a/specs/003-fatsecret-food-retrieval/data-model.md
+++ b/specs/003-fatsecret-food-retrieval/data-model.md
@@ -12,8 +12,8 @@ highres 1024×1024). The existing schema stores only `thumb` and `highres`.
 ```typescript
 // BEFORE
 export const foodPhotos = pgTable('food_photos', {
-  id: serial('id').primaryKey(),
-  foodId: integer('food_id').notNull().references(() => foods.id, { onDelete: 'cascade' }).unique(),
+  id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+  foodId: uuid('food_id').notNull().references(() => foods.id, { onDelete: 'cascade' }).unique(),
   thumb: varchar('thumb', { length: 500 }),
   highres: varchar('highres', { length: 500 }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -21,8 +21,8 @@ export const foodPhotos = pgTable('food_photos', {
 
 // AFTER — add medium column
 export const foodPhotos = pgTable('food_photos', {
-  id: serial('id').primaryKey(),
-  foodId: integer('food_id').notNull().references(() => foods.id, { onDelete: 'cascade' }).unique(),
+  id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+  foodId: uuid('food_id').notNull().references(() => foods.id, { onDelete: 'cascade' }).unique(),
   thumb: varchar('thumb', { length: 500 }),
   medium: varchar('medium', { length: 500 }),   // NEW: 400×400 URL
   highres: varchar('highres', { length: 500 }),
@@ -131,7 +131,7 @@ Used in `GET /api/foods/search` response only. Not a DB entity.
 
 ```typescript
 interface FoodSearchResultItem {
-  id: number | null;           // local DB id; null if not yet saved
+  id: string | null;           // local DB UUID; null if not yet saved
   fatSecretId: string;         // FatSecret food_id
   name: string;
   brandName: string | null;
@@ -154,7 +154,7 @@ Used in `GET /api/foods/detail?fatSecretId=...` response only.
 
 ```typescript
 interface FoodDetailResponse {
-  id: number;                 // local DB id
+  id: string;                 // local DB UUID
   fatSecretId: string;
   name: string;
   brandName: string | null;
@@ -177,7 +177,7 @@ interface FoodDetailResponse {
 }
 
 interface FoodServing {
-  id: number;                 // local DB id (foodAltMeasures.id)
+  id: string;                 // local DB UUID (foodAltMeasures.id)
   description: string;
   weightGrams: number;
   // Calculated fields (proportional from 100g base):

--- a/specs/004-food-search-field/data-model.md
+++ b/specs/004-food-search-field/data-model.md
@@ -10,7 +10,7 @@ These entities already exist in the DB schema and are **not modified** by this f
 
 ### `foods` (existing table)
 Relevant fields for this feature:
-- `id: number` — internal primary key
+- `id: string` — internal primary key (UUID7)
 - `sourceId: string | null` — FatSecret food ID (used as URL parameter for public page)
 - `source: string` — `'fatsecret'` for catalog foods, `'user_custom'` for custom
 - `name: string`
@@ -22,7 +22,7 @@ Relevant fields for this feature:
 - `thumbnail` — via `foodPhotos` join
 
 ### `foodPhotos` (existing table)
-- `foodId: number` — FK to `foods.id`
+- `foodId: string` — FK to `foods.id` (UUID7)
 - `thumb: string | null` — 72×72 image URL
 - `medium: string | null` — 400×400 image URL
 - `highres: string | null` — 1024×1024 image URL
@@ -57,7 +57,7 @@ Merges FatSecret results (Generic/Brand) and user custom foods into a single typ
 
 | Field | Type | Source |
 |-------|------|--------|
-| `id` | `number \| null` | Internal DB id; `null` if not yet cached locally |
+| `id` | `string \| null` | Internal DB UUID7; `null` if not yet cached locally |
 | `fatSecretId` | `string \| null` | FatSecret food_id; `null` for custom foods |
 | `name` | `string` | Food name |
 | `brandName` | `string \| null` | Brand name if applicable |
@@ -112,7 +112,7 @@ Props for the add-to-diary modal (food log page context).
 ```typescript
 interface CustomFoodSearchResponse {
   results: Array<{
-    id: number;
+    id: string;
     name: string;
     brandName: string | null;
     thumbnail: string | null;

--- a/specs/005-dashboard-redesign/data-model.md
+++ b/specs/005-dashboard-redesign/data-model.md
@@ -24,11 +24,10 @@ Tracks daily water intake per user. One row per user per calendar date.
 
 ```sql
 CREATE TABLE hydration_logs (
-  id          SERIAL PRIMARY KEY,
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
   date        DATE NOT NULL,
   total_ml    INTEGER NOT NULL DEFAULT 0,
-  goal_ml     INTEGER NOT NULL DEFAULT 2500,
   created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at  TIMESTAMP NOT NULL DEFAULT NOW(),
   UNIQUE (user_id, date)
@@ -39,21 +38,20 @@ CREATE INDEX hydration_logs_user_date_idx ON hydration_logs (user_id, date);
 
 ### Field Notes
 - `total_ml`: Cumulative milliliters logged for the day. Incremented by 250 per glass.
-- `goal_ml`: Daily target in milliliters. Defaults to 2500 (2.5L). Stored per-row to allow future per-user goal customization without joining `nutritionGoals`.
 - `UNIQUE(user_id, date)`: Prevents duplicate rows; enables upsert on add-water action.
+- **Hydration goal**: Sourced from `nutrition_goals.target_hydration_ml` (default 2500 ml) at query time. Not stored on `hydration_logs`.
 
 ### Drizzle Schema Addition (in `src/server/db/schema.ts`)
 ```typescript
 export const hydrationLogs = pgTable(
   'hydration_logs',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
     date: date('date').notNull(),
     totalMl: integer('total_ml').notNull().default(0),
-    goalMl: integer('goal_ml').notNull().default(2500),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
@@ -105,7 +103,7 @@ Daily water intake record.
 | `date` | `string` (ISO date) | Today | |
 | `totalMl` | `number` | `hydration_logs.total_ml` | 0 if no row exists yet |
 | `totalLiters` | `number` | `totalMl / 1000` | Rounded to 1 decimal |
-| `goalMl` | `number` | `hydration_logs.goal_ml` | Default 2500 |
+| `goalMl` | `number` | `nutrition_goals.target_hydration_ml` | Default 2500 if no goal row |
 | `percentConsumed` | `number` | `totalMl / goalMl × 100` | Clamped 0–100 for progress bar |
 | `hasGoal` | `boolean` | Always `true` (default goal applied) | No separate goal config yet |
 
@@ -142,7 +140,7 @@ A single logged meal or activity for the current day.
 
 | Field | Type | Source | Notes |
 |-------|------|--------|-------|
-| `id` | `number` | `food_log_meals.id` | |
+| `id` | `string` | `food_log_meals.id` | UUID7 |
 | `name` | `string` | First `food_log_items.food_name` in the meal | Or meal type label if no items |
 | `time` | `string` | `food_log_meals.consumed_at` formatted | e.g., "08:00 AM" |
 | `timeGroup` | `"morning" \| "midday" \| "evening"` | Derived from `consumed_at` hour | See mapping below |

--- a/specs/005-dashboard-redesign/research.md
+++ b/specs/005-dashboard-redesign/research.md
@@ -91,14 +91,16 @@ A new **`hydration_logs` database table** must be created. The schema currently 
 
 ```
 hydration_logs
-  id              serial PK
+  id              uuid PK (UUID7)
   user_id         text FK → users.id
   date            date NOT NULL
   total_ml        integer NOT NULL DEFAULT 0
-  goal_ml         integer NOT NULL DEFAULT 2500
   created_at      timestamp
   updated_at      timestamp
   UNIQUE(user_id, date)
+```
+Hydration goal is sourced from `nutrition_goals.target_hydration_ml` (default 2500 ml) — not stored on this table.
+```
 ```
 
 The quick-add water button increments `total_ml` by 250 (one glass). The upsert pattern (`INSERT ... ON CONFLICT DO UPDATE`) ensures one row per user per day.

--- a/src/app/(dashboard)/food-log/page.tsx
+++ b/src/app/(dashboard)/food-log/page.tsx
@@ -50,7 +50,7 @@ export default function FoodLogPage() {
     foodSearch.setQuery('');
   };
 
-  const handleDeleteLog = async (logId: number) => {
+  const handleDeleteLog = async (logId: string) => {
     await deleteMutation.mutateAsync(logId);
   };
 

--- a/src/app/(dashboard)/goals/page.tsx
+++ b/src/app/(dashboard)/goals/page.tsx
@@ -15,7 +15,7 @@ import { useNutritionGoals } from '@/hooks/use-nutrition-goals';
 import type { ActivityLevel, GoalType } from '@/types/goals';
 import { useForm } from '@tanstack/react-form';
 import { Loader2, Target } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type GoalsFormValues = {
   goalType: GoalType;
@@ -63,6 +63,20 @@ export default function GoalsPage() {
       }
     },
   });
+
+  useEffect(() => {
+    if (!goals) return;
+    form.reset({
+      goalType: (goals.goalType as GoalType) || 'maintenance',
+      activityLevel: (goals.activityLevel as ActivityLevel) || 'moderate',
+      calories: goals.calories?.toString() || '2000',
+      protein: goals.protein?.toString() || '150',
+      carbs: goals.carbs?.toString() || '250',
+      fat: goals.fat?.toString() || '65',
+      fiber: goals.fiber?.toString() || '25',
+      sodium: goals.sodium?.toString() || '2300',
+    });
+  }, [goals]);
 
   if (isLoading) {
     return (

--- a/src/app/api/diet-plans/[dietPlanId]/meal-groups/route.ts
+++ b/src/app/api/diet-plans/[dietPlanId]/meal-groups/route.ts
@@ -31,7 +31,7 @@ const createMealGroupSchema = z.object({
   items: z
     .array(
       z.object({
-        foodId: z.number().int().positive(),
+        foodId: z.string().uuid(),
         quantity: z.number().positive().max(10000),
         servingUnit: z.string().min(1).max(100).optional(),
       }),
@@ -40,12 +40,9 @@ const createMealGroupSchema = z.object({
     .max(100),
 });
 
-function parseDietPlanId(raw: string) {
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    return null;
-  }
-  return value;
+function parseDietPlanId(raw: string): string | null {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(raw.trim()) ? raw.trim() : null;
 }
 
 export async function GET(
@@ -103,18 +100,18 @@ export async function GET(
       .leftJoin(foodPhotos, eq(dietPlanMealItems.foodId, foodPhotos.foodId))
       .where(eq(dietPlanMealGroups.dietPlanId, dietPlanId));
 
-    const grouped = new Map<number, {
-      id: number;
+    const grouped = new Map<string, {
+      id: string;
       mealType: string;
       dayOfWeek: number | null;
       scheduledAt: Date | null;
       createdAt: Date;
       items: Array<{
-        id: number;
+        id: string;
         quantity: number;
         servingUnit: string | null;
         food: {
-          id: number | null;
+          id: string | null;
           name: string;
           brandName: string | null;
           calories: number;
@@ -211,7 +208,7 @@ export async function POST(
     const payload = validation.data;
 
     const foodsById = new Map<
-      number,
+      string,
       {
         food: Awaited<ReturnType<typeof db.query.foods.findFirst>>;
         photoThumb: string | null;

--- a/src/app/api/food-logs/[id]/route.ts
+++ b/src/app/api/food-logs/[id]/route.ts
@@ -83,7 +83,7 @@ export async function GET(
         createdAt: itemLog.createdAt,
         food: {
           ...itemLog.food,
-          id: itemLog.food.id || 0,
+          id: itemLog.food.id ?? null,
           calories: toNumber(itemLog.food.calories),
           protein: toNumber(itemLog.food.protein),
           carbs: toNumber(itemLog.food.carbs),

--- a/src/app/api/foods/detail/route.ts
+++ b/src/app/api/foods/detail/route.ts
@@ -28,14 +28,14 @@ export async function GET(request: NextRequest) {
   // Build the where condition: prefer local DB id, fall back to source_id lookup
   let whereCondition;
   if (rawId && rawId.trim() !== '') {
-    const id = parseInt(rawId, 10);
-    if (isNaN(id) || id <= 0) {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(rawId.trim())) {
       return NextResponse.json(
-        { success: false, error: 'id must be a positive integer.', field: 'id' },
+        { success: false, error: 'id must be a valid UUID.', field: 'id' },
         { status: 400 },
       );
     }
-    whereCondition = and(eq(foods.id, id), isNotNull(foods.calories));
+    whereCondition = and(eq(foods.id, rawId.trim()), isNotNull(foods.calories));
   } else {
     whereCondition = and(
       eq(foods.source, 'fatsecret'),

--- a/src/app/foods/[fatSecretId]/page.tsx
+++ b/src/app/foods/[fatSecretId]/page.tsx
@@ -12,7 +12,7 @@ interface PageProps {
 }
 
 interface FoodData {
-  id: number | null;
+  id: string | null;
   name: string;
   brandName: string | null;
   foodType: string | null;
@@ -31,7 +31,7 @@ interface FoodData {
   iron: number | null;
   images: { thumb: string | null; medium: string | null; highres: string | null } | null;
   servings: Array<{
-    id: number;
+    id: string;
     description: string;
     weightGrams: number;
     calories: number;
@@ -156,7 +156,7 @@ async function getFoodFromFatSecret(fatSecretId: string): Promise<FoodData | nul
         const baseCarbs = parseFloat(baseServing.carbohydrate);
         const baseFat = parseFloat(baseServing.fat);
         return {
-          id: i + 1,
+          id: String(i + 1),
           description: s.serving_description,
           weightGrams: w,
           calories: parseFloat((baseCalories * w / 100).toFixed(0)),

--- a/src/components/food-log-client.tsx
+++ b/src/components/food-log-client.tsx
@@ -35,7 +35,7 @@ interface FoodLogClientProps {
   totals: Totals;
   isLoading?: boolean;
   onDateChange: (date: Date) => void;
-  onDeleteLog: (logId: number) => Promise<void>;
+  onDeleteLog: (logId: string) => Promise<void>;
 }
 
 
@@ -48,8 +48,8 @@ export default function FoodLogClient({
   onDeleteLog
 }: FoodLogClientProps) {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [deleting, setDeleting] = useState<number | null>(null);
-  const [confirmingDelete, setConfirmingDelete] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const handlePreviousDay = () => {
@@ -70,12 +70,12 @@ export default function FoodLogClient({
     onDateChange(newDate);
   };
 
-  const handleDeleteRequest = (logId: number) => {
+  const handleDeleteRequest = (logId: string) => {
     setConfirmingDelete(logId);
     setDeleteError(null);
   };
 
-  const handleDeleteConfirm = async (logId: number) => {
+  const handleDeleteConfirm = async (logId: string) => {
     setDeleting(logId);
     setConfirmingDelete(null);
     try {

--- a/src/components/food-search-field/types.ts
+++ b/src/components/food-search-field/types.ts
@@ -1,5 +1,5 @@
 export interface UnifiedFoodSearchResultItem {
-  id: number | null;
+  id: string | null;
   fatSecretId: string | null;
   name: string;
   brandName: string | null;

--- a/src/lib/api-validation.ts
+++ b/src/lib/api-validation.ts
@@ -144,9 +144,7 @@ export const nutritionGoalsSchema = z.object({
 // Food log ID validation
 export const foodLogIdSchema = z
   .string()
-  .regex(/^\d+$/, 'Food log ID must be a valid number')
-  .transform((val) => parseInt(val, 10))
-  .refine((val) => val > 0, 'Food log ID must be a positive number');
+  .uuid('Food log ID must be a valid UUID');
 
 // ============================================
 // TRANSFORMATION HELPERS

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -81,9 +81,8 @@ export const nutritionGoalsSchema = z.object({
 })
 
 // Food log ID validation
-export const foodLogIdSchema = z.number()
-  .int('Food log ID must be an integer')
-  .positive('Food log ID must be positive')
+export const foodLogIdSchema = z.string()
+  .uuid('Food log ID must be a valid UUID')
 
 // ============================================
 // VALIDATION HELPER FUNCTIONS
@@ -125,6 +124,6 @@ export function validateNutritionGoals(goals: unknown): z.infer<typeof nutrition
   return validateAndSanitize(nutritionGoalsSchema, goals, 'nutrition goals')
 }
 
-export function validateFoodLogId(id: number): number {
+export function validateFoodLogId(id: string): string {
   return validateAndSanitize(foodLogIdSchema, id, 'food log ID')
 }

--- a/src/queries/custom-foods.ts
+++ b/src/queries/custom-foods.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 interface CustomFoodSearchResult {
-  id: number;
+  id: string;
   name: string;
   brandName: string | null;
   thumbnail: string | null;

--- a/src/queries/food-detail.ts
+++ b/src/queries/food-detail.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 export interface FoodServing {
-  id: number;
+  id: string;
   description: string;
   weightGrams: number;
   calories: number;
@@ -20,7 +20,7 @@ export interface FoodImages {
 }
 
 export interface FoodDetailResponse {
-  id: number;
+  id: string;
   name: string;
   brandName: string | null;
   foodType: 'Generic' | 'Brand';
@@ -44,7 +44,7 @@ export interface FoodDetailResponse {
   images: FoodImages | null;
 }
 
-export type FoodSelection = { id: number; fatSecretId?: string } | { id: null; fatSecretId: string };
+export type FoodSelection = { id: string; fatSecretId?: string } | { id: null; fatSecretId: string };
 
 export function useFoodDetailQuery(selection: FoodSelection | null) {
   return useQuery({

--- a/src/queries/food-logs.ts
+++ b/src/queries/food-logs.ts
@@ -83,7 +83,7 @@ export function useDeleteFoodLogMutation() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (logId: number): Promise<void> => {
+    mutationFn: async (logId: string): Promise<void> => {
       const response = await fetch(`/api/food-logs/${logId}`, {
         method: 'DELETE',
       })

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -8,13 +8,14 @@ import {
   jsonb,
   pgEnum,
   pgTable,
-  serial,
   text,
   timestamp,
   unique,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import { uuidv7 } from 'uuidv7';
 
 // Enums
 export const userRoleEnum = pgEnum('user_role', [
@@ -184,7 +185,7 @@ export const securityEvents = pgTable(
 export const foods = pgTable(
   'foods',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     sourceId: varchar('source_id', { length: 100 }),
     source: varchar('source', { length: 100 }).notNull().default('user_custom'),
     name: varchar('name', { length: 500 }).notNull(),
@@ -222,8 +223,8 @@ export const foods = pgTable(
 export const foodPhotos = pgTable(
   'food_photos',
   {
-    id: serial('id').primaryKey(),
-    foodId: integer('food_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    foodId: uuid('food_id')
       .notNull()
       .references(() => foods.id, { onDelete: 'cascade' })
       .unique(),
@@ -238,8 +239,8 @@ export const foodPhotos = pgTable(
 export const foodAltMeasures = pgTable(
   'food_alt_measures',
   {
-    id: serial('id').primaryKey(),
-    foodId: integer('food_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    foodId: uuid('food_id')
       .notNull()
       .references(() => foods.id, { onDelete: 'cascade' }),
     servingWeight: decimal('serving_weight', {
@@ -276,13 +277,13 @@ const foodSnapshotColumns = {
 export const foodLogMeals = pgTable(
   'food_log_meals',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
     mealType: mealTypeEnum('meal_type').notNull(),
     consumedAt: timestamp('consumed_at').notNull(),
-    sourceDietPlanMealGroupId: integer('source_diet_plan_meal_group_id').references(
+    sourceDietPlanMealGroupId: uuid('source_diet_plan_meal_group_id').references(
       () => dietPlanMealGroups.id,
       { onDelete: 'set null' },
     ),
@@ -303,11 +304,11 @@ export const foodLogMeals = pgTable(
 export const foodLogItems = pgTable(
   'food_log_items',
   {
-    id: serial('id').primaryKey(),
-    mealId: integer('meal_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    mealId: uuid('meal_id')
       .notNull()
       .references(() => foodLogMeals.id, { onDelete: 'cascade' }),
-    foodId: integer('food_id').references(() => foods.id, { onDelete: 'set null' }),
+    foodId: uuid('food_id').references(() => foods.id, { onDelete: 'set null' }),
     quantity: decimal('quantity', { precision: 10, scale: 2 }).notNull(),
     servingUnit: varchar('serving_unit', { length: 100 }),
     ...foodSnapshotColumns,
@@ -324,7 +325,7 @@ export const foodLogItems = pgTable(
 export const nutritionGoals = pgTable(
   'nutrition_goals',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -386,11 +387,11 @@ export const nutritionGoals = pgTable(
 export const bodyCheckins = pgTable(
   'body_checkins',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    goalId: integer('goal_id').references(() => nutritionGoals.id, {
+    goalId: uuid('goal_id').references(() => nutritionGoals.id, {
       onDelete: 'set null',
     }),
     checkInDate: timestamp('check_in_date').notNull(),
@@ -422,7 +423,7 @@ export const bodyCheckins = pgTable(
 export const dietPlans = pgTable(
   'diet_plans',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     clientId: text('client_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -447,11 +448,11 @@ export const dietPlans = pgTable(
 export const dietPlanMeals = pgTable(
   'diet_plan_meals',
   {
-    id: serial('id').primaryKey(),
-    dietPlanId: integer('diet_plan_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    dietPlanId: uuid('diet_plan_id')
       .notNull()
       .references(() => dietPlans.id, { onDelete: 'cascade' }),
-    foodId: integer('food_id')
+    foodId: uuid('food_id')
       .notNull()
       .references(() => foods.id, { onDelete: 'cascade' }),
     mealType: mealTypeEnum('meal_type').notNull(),
@@ -469,8 +470,8 @@ export const dietPlanMeals = pgTable(
 export const dietPlanMealGroups = pgTable(
   'diet_plan_meal_groups',
   {
-    id: serial('id').primaryKey(),
-    dietPlanId: integer('diet_plan_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    dietPlanId: uuid('diet_plan_id')
       .notNull()
       .references(() => dietPlans.id, { onDelete: 'cascade' }),
     mealType: mealTypeEnum('meal_type').notNull(),
@@ -492,11 +493,11 @@ export const dietPlanMealGroups = pgTable(
 export const dietPlanMealItems = pgTable(
   'diet_plan_meal_items',
   {
-    id: serial('id').primaryKey(),
-    groupId: integer('group_id')
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
+    groupId: uuid('group_id')
       .notNull()
       .references(() => dietPlanMealGroups.id, { onDelete: 'cascade' }),
-    foodId: integer('food_id').references(() => foods.id, { onDelete: 'set null' }),
+    foodId: uuid('food_id').references(() => foods.id, { onDelete: 'set null' }),
     quantity: decimal('quantity', { precision: 10, scale: 2 }).notNull(),
     servingUnit: varchar('serving_unit', { length: 100 }),
     ...foodSnapshotColumns,
@@ -514,7 +515,7 @@ export const dietPlanMealItems = pgTable(
 export const hydrationLogs = pgTable(
   'hydration_logs',
   {
-    id: serial('id').primaryKey(),
+    id: uuid('id').primaryKey().notNull().$defaultFn(() => uuidv7()),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -425,12 +425,12 @@ type GoalVariant =
 // Generate food logs for the past 14 days
 function generateFoodLogs(
   userId: string,
-  foodIds: number[],
+  foodIds: string[],
   variant: GoalVariant
 ) {
   const logs: Array<{
     userId: string;
-    foodId: number;
+    foodId: string;
     quantity: string;
     servingUnit: string | null;
     mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack';
@@ -588,7 +588,7 @@ async function insertGroupedFoodLogs(
   userId: string,
   logs: Array<{
     userId: string;
-    foodId: number;
+    foodId: string;
     quantity: string;
     servingUnit: string | null;
     mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack';

--- a/src/server/services/dashboard.service.ts
+++ b/src/server/services/dashboard.service.ts
@@ -52,7 +52,7 @@ export interface WeeklySnapshotDTO {
 }
 
 export interface ScheduleEntry {
-  id: number;
+  id: string;
   name: string;
   time: string;
   timeGroup: 'morning' | 'midday' | 'evening';
@@ -452,9 +452,9 @@ export async function getDailySchedule(
 
   // Group rows by meal
   const mealsMap = new Map<
-    number,
+    string,
     {
-      mealId: number;
+      mealId: string;
       mealType: string;
       consumedAt: Date;
       firstName: string | null;

--- a/src/server/services/food-search.service.ts
+++ b/src/server/services/food-search.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@/types/fatsecret';
 
 export interface FoodSearchResultItem {
-  id: number | null;
+  id: string | null;
   fatSecretId: string;
   name: string;
   brandName: string | null;

--- a/src/types/food.ts
+++ b/src/types/food.ts
@@ -26,7 +26,7 @@ export interface Nutrient {
 }
 
 export interface BaseFood {
-  id: number;
+  id: string;
   sourceId: string | null; // Generic ID from source system
   sourceType: FoodSource;
   name: string;
@@ -53,9 +53,9 @@ export interface BaseFood {
 }
 
 export interface FoodLogEntry {
-  id: number;
+  id: string;
   userId: string;
-  foodId: number;
+  foodId: string;
   quantity: number;
   servingUnit?: string;
   mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack';

--- a/src/types/goals.ts
+++ b/src/types/goals.ts
@@ -41,7 +41,7 @@ export interface NutritionGoalWizardInputsSnapshot {
 }
 
 export interface NutritionGoalHistoryRecord {
-  id: number;
+  id: string;
   goalType: GoalType;
   activityLevel?: ActivityLevel | null;
   startDate: string;
@@ -74,9 +74,9 @@ export type CheckinPhotoKey = 'front' | 'back' | 'left' | 'right';
 export type BodyCheckinPhotos = Partial<Record<CheckinPhotoKey, string>>;
 
 export interface BodyCheckin {
-  id: number;
+  id: string;
   userId: string;
-  goalId?: number | null;
+  goalId?: string | null;
   checkInDate: string;
 
   weightKg: number;


### PR DESCRIPTION
- Updated FoodLogPage to accept string log IDs for deletion.
- Enhanced GoalsPage to reset form values based on fetched goals.
- Modified API routes for meal groups and food logs to use UUIDs.
- Adjusted food detail and food search components to handle string IDs.
- Updated validation schemas to enforce UUID format for food log IDs.
- Refactored database schema to replace integer IDs with UUIDs for various tables.
- Seed script updated to generate UUIDs for food logs and related entities.