### PR TITLE
feat: implement meal logging from diet plan

### DIFF
--- a/e2e/006-food-log-redesign.spec.ts
+++ b/e2e/006-food-log-redesign.spec.ts
@@ -5,6 +5,49 @@ import { LoginPage } from './pages/login.page';
 import { format, addDays, startOfWeek } from 'date-fns';
 
 test.describe('006: Food Log Screen Redesign', () => {
+  async function createPlanViaApi(page: import('@playwright/test').Page, data: {
+    name: string;
+    targetCalories: number;
+    targetProtein: number;
+    targetCarbs: number;
+    targetFat: number;
+    status: 'active' | 'draft' | 'archived';
+    startDate?: string;
+  }) {
+    const res = await page.request.post('/api/diet-plans', {
+      data: {
+        ...data,
+        startDate: data.startDate ?? new Date().toISOString(),
+      },
+    });
+
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    return body.plan.id as string;
+  }
+
+  async function createMealViaApi(
+    page: import('@playwright/test').Page,
+    planId: string,
+    mealType: string,
+    dayOfWeek: number,
+  ) {
+    const res = await page.request.post(`/api/diet-plans/${planId}/meals`, {
+      data: { mealType, dayOfWeek },
+    });
+
+    expect(res.ok()).toBeTruthy();
+  }
+
+  async function deletePlanViaApi(page: import('@playwright/test').Page, planId: string) {
+    await page.request.delete(`/api/diet-plans/${planId}`);
+  }
+
+  function getDbDayOfWeek(date: Date) {
+    const day = date.getUTCDay();
+    return day === 0 ? 7 : day;
+  }
+
   async function loginAsTestUser(page: import('@playwright/test').Page) {
     const loginPage = new LoginPage(page);
     await loginPage.goto();
@@ -182,28 +225,49 @@ test.describe('006: Food Log Screen Redesign', () => {
   });
 
   test.describe('Meal Card Design', () => {
-    test('all four meal type sections are rendered', async ({ page }) => {
+    test('renders only meal sections that have logs or a plan', async ({ page }) => {
       await loginAsTestUser(page);
       const foodLogPage = new FoodLogPage(page);
       await foodLogPage.goto();
 
-      await expect(page.getByTestId('meal-section-breakfast')).toBeVisible();
-      await expect(page.getByTestId('meal-section-lunch')).toBeVisible();
-      await expect(page.getByTestId('meal-section-dinner')).toBeVisible();
-      await expect(page.getByTestId('meal-section-snack')).toBeVisible();
+      const mealSections = page.locator('[data-testid^="meal-section-"]');
+      await expect.poll(async () => mealSections.count(), { timeout: 10000 }).toBeGreaterThan(0);
+
+      const visibleSectionCount = await mealSections.count();
+      expect(visibleSectionCount).toBeLessThanOrEqual(4);
     });
 
-    test('empty meal placeholders appear for unlogged meals (fresh user)', async ({ page }) => {
+    test('empty meal placeholders appear for unlogged planned meals', async ({ page }) => {
       await loginAsFreshUser(page);
       const foodLogPage = new FoodLogPage(page);
-      await foodLogPage.goto();
+      const today = new Date();
+      const dayOfWeek = getDbDayOfWeek(today);
+      const planId = await createPlanViaApi(page, {
+        name: `E2E Empty Meal Plan ${Date.now()}`,
+        targetCalories: 2000,
+        targetProtein: 150,
+        targetCarbs: 200,
+        targetFat: 70,
+        status: 'active',
+        startDate: today.toISOString(),
+      });
 
-      // Empty sections start collapsed — expand breakfast to see its placeholder
-      await expect(page.getByTestId('meal-section-breakfast')).toBeVisible({ timeout: 10000 });
-      await page.getByTestId('meal-toggle-breakfast').click();
+      try {
+        await createMealViaApi(page, planId, 'breakfast', dayOfWeek);
+        await foodLogPage.goto();
 
-      const placeholder = page.getByTestId('meal-empty-placeholder-breakfast');
-      await expect(placeholder).toBeVisible({ timeout: 5000 });
+        const breakfastSection = page.getByTestId('meal-section-breakfast');
+        await expect(breakfastSection).toBeVisible({ timeout: 10000 });
+
+        const toggle = page.getByTestId('meal-toggle-breakfast');
+        if ((await toggle.getAttribute('aria-expanded')) === 'false') {
+          await toggle.click();
+        }
+
+        await expect(page.getByTestId('meal-empty-placeholder-breakfast')).toBeVisible({ timeout: 5000 });
+      } finally {
+        await deletePlanViaApi(page, planId);
+      }
     });
 
     test('food items show in logged meal sections (seeded user)', async ({ page }) => {

--- a/e2e/log-meal-plan.spec.ts
+++ b/e2e/log-meal-plan.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from '@playwright/test';
+import { format, startOfWeek } from 'date-fns';
+import { AUTH_FILES } from './fixtures/test-data';
+import { FoodLogPage } from './pages/food-log.page';
+
+test.describe.configure({ mode: 'serial' });
+
+const plannerDate = format(startOfWeek(new Date(), { weekStartsOn: 1 }), 'yyyy-MM-dd');
+
+async function freezeClientTimeAfter18(page: Page, dateStr: string) {
+  await page.addInitScript(({ isoString }) => {
+    const RealDate = Date;
+    const fixedTime = new RealDate(isoString);
+
+    class MockDate extends RealDate {
+      constructor(...args: unknown[]) {
+        if (args.length === 0) {
+          super(fixedTime.getTime());
+          return;
+        }
+
+        super(...(args as ConstructorParameters<typeof Date>));
+      }
+
+      static now() {
+        return fixedTime.getTime();
+      }
+    }
+
+    MockDate.parse = RealDate.parse;
+    MockDate.UTC = RealDate.UTC;
+    MockDate.prototype = RealDate.prototype;
+    // @ts-expect-error overriding Date in the browser for deterministic E2E coverage
+    window.Date = MockDate;
+    // @ts-expect-error overriding Date in the browser for deterministic E2E coverage
+    globalThis.Date = MockDate;
+  }, { isoString: `${dateStr}T19:00:00` });
+}
+
+async function clearBannerDismissState(page: Page) {
+  await page.evaluate(() => {
+    const keysToRemove: string[] = [];
+
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key?.startsWith('vitalis-plan-banner-')) {
+        keysToRemove.push(key);
+      }
+    }
+
+    for (const key of keysToRemove) {
+      window.localStorage.removeItem(key);
+    }
+  });
+}
+
+async function clearFoodLogsForDate(page: Page, date: string) {
+  const response = await page.request.get(`/api/food-logs?date=${date}`);
+  expect(response.ok()).toBeTruthy();
+
+  const body = await response.json();
+  for (const log of body.logs as Array<{ id: string }>) {
+    const deleteResponse = await page.request.delete(`/api/food-logs/${log.id}`);
+    expect(deleteResponse.ok()).toBeTruthy();
+  }
+}
+
+test.describe('Meal planner integration banner and actions', () => {
+  test.use({ storageState: AUTH_FILES.testUser });
+
+  test.beforeEach(async ({ page }) => {
+    const foodLogPage = new FoodLogPage(page);
+    await freezeClientTimeAfter18(page, plannerDate);
+    await foodLogPage.goto(plannerDate);
+    await clearBannerDismissState(page);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('shows the planner banner and persists dismissal for the selected date', async ({ page }) => {
+    const foodLogPage = new FoodLogPage(page);
+    await clearFoodLogsForDate(page, plannerDate);
+    await foodLogPage.goto(plannerDate);
+    await clearBannerDismissState(page);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(foodLogPage.mealPlanBanner).toBeVisible();
+    await expect(foodLogPage.mealPlanBanner).toContainText(/balanced weight loss/i);
+
+    await foodLogPage.mealPlanBannerDismiss.click();
+    await expect(foodLogPage.mealPlanBanner).not.toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(foodLogPage.mealPlanBanner).not.toBeVisible();
+  });
+
+  test('add-all logs the plan and hides planner prompts once covered', async ({ page }) => {
+    const foodLogPage = new FoodLogPage(page);
+    await clearFoodLogsForDate(page, plannerDate);
+    await foodLogPage.goto(plannerDate);
+    await clearBannerDismissState(page);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(foodLogPage.mealPlanBanner).toBeVisible();
+    await foodLogPage.logAllMealsButton.click();
+    await expect(foodLogPage.logMealsModal).toBeVisible();
+    await expect(foodLogPage.logMealsModal).toContainText(/select one of the options above to continue\./i);
+    await foodLogPage.logMealsAddButton.click();
+    await expect(foodLogPage.logMealsModal).not.toBeVisible({ timeout: 10000 });
+
+    const firstRowCount = await page.locator('[data-testid^="food-log-"]').count();
+    expect(firstRowCount).toBeGreaterThan(0);
+
+    await expect(foodLogPage.mealPlanBanner).not.toBeVisible();
+    await expect(page.locator('[data-testid^="meal-plan-addon-"]')).toHaveCount(0);
+  });
+
+  test('per-meal log plan hides that meal addon once planned foods are logged', async ({ page }) => {
+    const foodLogPage = new FoodLogPage(page);
+    await clearFoodLogsForDate(page, plannerDate);
+    await foodLogPage.goto(plannerDate);
+    await clearBannerDismissState(page);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const addon = page.locator('[data-testid^="meal-plan-addon-"]').first();
+    await expect(addon).toBeVisible();
+
+    const addonTestId = await addon.getAttribute('data-testid');
+    const mealType = addonTestId?.replace('meal-plan-addon-', '');
+
+    expect(mealType).toBeTruthy();
+
+    await foodLogPage.logPlanButton(mealType!).click();
+    await expect.poll(async () => foodLogPage.mealRows(mealType!).count(), { timeout: 10000 }).toBeGreaterThan(0);
+    await expect(page.locator(`[data-testid="meal-plan-addon-${mealType}"]`)).toHaveCount(0);
+  });
+});
+
+test.describe('Meal planner integration without active plan', () => {
+  test.use({ storageState: AUTH_FILES.generalHealth });
+
+  test('does not show the banner or meal addons', async ({ page }) => {
+    const foodLogPage = new FoodLogPage(page);
+    await foodLogPage.goto(plannerDate);
+
+    await expect(foodLogPage.mealPlanBanner).not.toBeVisible();
+    await expect(page.locator('[data-testid^="meal-plan-addon-"]')).toHaveCount(0);
+  });
+});

--- a/e2e/pages/food-log.page.ts
+++ b/e2e/pages/food-log.page.ts
@@ -4,6 +4,12 @@ import { format, startOfWeek, addDays } from 'date-fns';
 export class FoodLogPage {
   readonly page: Page;
   readonly heading: Locator;
+  readonly mealPlanBanner: Locator;
+  readonly mealPlanBannerDismiss: Locator;
+  readonly logAllMealsButton: Locator;
+  readonly logMealsModal: Locator;
+  readonly logMealsAddButton: Locator;
+  readonly logMealsReplaceButton: Locator;
   readonly searchInput: Locator;
   readonly searchResults: Locator;
   readonly quantityInput: Locator;
@@ -34,6 +40,12 @@ export class FoodLogPage {
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: 'Meal Planner & Daily Intake' });
+    this.mealPlanBanner = page.getByTestId('meal-plan-banner');
+    this.mealPlanBannerDismiss = page.getByTestId('meal-plan-banner-dismiss');
+    this.logAllMealsButton = page.getByTestId('log-all-meals-btn');
+    this.logMealsModal = page.getByTestId('log-meals-modal');
+    this.logMealsAddButton = page.getByTestId('log-meals-add-btn');
+    this.logMealsReplaceButton = page.getByTestId('log-meals-replace-btn');
     this.searchInput = page.getByTestId('food-search-input');
     this.searchResults = page.getByTestId('food-search-dropdown');
     this.quantityInput = page.getByTestId('quantity-input');
@@ -62,9 +74,25 @@ export class FoodLogPage {
     this.cancelButton = page.getByTestId('food-modal-cancel');
   }
 
-  async goto() {
-    await this.page.goto('/food-log');
+  async goto(date?: string) {
+    await this.page.goto(date ? `/food-log?date=${date}` : '/food-log');
     await this.page.waitForLoadState('networkidle');
+  }
+
+  mealPlanAddon(mealType: string) {
+    return this.page.getByTestId(`meal-plan-addon-${mealType}`);
+  }
+
+  logPlanButton(mealType: string) {
+    return this.page.getByTestId(`log-plan-btn-${mealType}`);
+  }
+
+  mealSection(mealType: string) {
+    return this.page.getByTestId(`meal-section-${mealType}`);
+  }
+
+  mealRows(mealType: string) {
+    return this.mealSection(mealType).locator('[data-testid^="food-log-"]');
   }
 
   async searchFood(query: string) {

--- a/src/app/(dashboard)/food-log/food-log-content.tsx
+++ b/src/app/(dashboard)/food-log/food-log-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { format, isValid, parseISO } from 'date-fns';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { FoodSearchField } from '@/components/food-search-field';
@@ -8,18 +8,22 @@ import { CreatePlanButton, CreateFoodButton } from '@/components/create-action-b
 import { FoodLogAddModal } from '@/components/food-log-add-modal';
 import { DishLogModal } from '@/components/dish-log-modal';
 import FoodLogClient from '@/components/food-log-client';
+import { LogMealsModal } from '@/components/food-log/log-meals-modal';
+import { MealPlanBanner } from '@/components/food-log/meal-plan-banner';
 import { NutritionPulse } from '@/components/food-log/nutrition-pulse';
 import { WeeklyCalendarStrip } from '@/components/food-log/weekly-calendar-strip';
-import { useFoodLogsQuery, useDeleteFoodLogMutation } from '@/queries/food-logs';
+import { useFoodLogsQuery, useDeleteFoodLogMutation, useLogFromPlanMutation } from '@/queries/food-logs';
 import { useDeleteDishGroupMutation } from '@/queries/dishes';
 import { useFoodDetailQuery, type FoodSelection } from '@/queries/food-detail';
 import { FoodModal } from '@/components/food-modal';
 import { PageHeader } from '@/components/page-header';
 import type { MealType } from '@/lib/nutrition-constants';
+import { usePlanMealsForDate } from '@/queries/diet-plans';
 import type { FoodLogEntry } from '@/types/food';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Plus, Search } from 'lucide-react';
+import { toast } from 'sonner';
 
 const EMPTY_FOOD_DETAIL: import('@/queries/food-detail').FoodDetailResponse = {
   id: '', name: '', brandName: null, foodType: 'Generic', foodUrl: null,
@@ -33,6 +37,7 @@ import type { FavoriteItem } from '@/types/favorites';
 export function FoodLogContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [now, setNow] = useState(() => new Date());
 
   const [selectedDate, setSelectedDate] = useState(() => {
     const dateParam = searchParams.get('date');
@@ -45,6 +50,8 @@ export function FoodLogContent() {
   const [selectedFood, setSelectedFood] = useState<UnifiedFoodSearchResultItem | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+  const [logMealsModalOpen, setLogMealsModalOpen] = useState(false);
+  const [loggingMealType, setLoggingMealType] = useState<MealType | null>(null);
 
   // Edit modal state
   const [lastAdded, setLastAdded] = useState<{ mealType: MealType; seq: number } | null>(null);
@@ -62,6 +69,8 @@ export function FoodLogContent() {
   const mobileSubtitle = useMemo(() => format(selectedDate, 'MMMM d'), [selectedDate]);
 
   const logsQuery = useFoodLogsQuery(dateStr);
+  const planMeals = usePlanMealsForDate(dateStr);
+  const logFromPlanMutation = useLogFromPlanMutation();
   const deleteMutation = useDeleteFoodLogMutation();
   const deleteDishGroupMutation = useDeleteDishGroupMutation();
   const foodSearch = useFoodSearch({ includeCustom: true });
@@ -75,6 +84,39 @@ export function FoodLogContent() {
     : null;
 
   const detailQuery = useFoodDetailQuery(foodSelection);
+
+  const hasLoggedAllPlannedMeals = useMemo(() => {
+    const plannedMeals = Object.entries(planMeals.planMealsByMealType).filter(([, meal]) => {
+      return !!meal && meal.items.length > 0;
+    });
+
+    if (plannedMeals.length === 0) {
+      return false;
+    }
+
+    const logsByMeal = logsQuery.data?.logsByMeal ?? {};
+
+    return plannedMeals.every(([mealType]) => {
+      return (logsByMeal[mealType] ?? []).length > 0;
+    });
+  }, [logsQuery.data?.logsByMeal, planMeals.planMealsByMealType]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setNow(new Date());
+    }, 60_000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  const shouldShowPlanBanner =
+    planMeals.activePlan &&
+    planMeals.hasPlanForDay &&
+    !hasLoggedAllPlannedMeals &&
+    now.getHours() >= 18;
+  const bannerPlan = shouldShowPlanBanner ? planMeals.activePlan : null;
 
   const handleSelect = (item: UnifiedFoodSearchResultItem) => {
     if (item.itemKind === 'dish' && item.dishId) {
@@ -132,6 +174,26 @@ export function FoodLogContent() {
     router.replace(`/food-log?date=${format(date, 'yyyy-MM-dd')}`, { scroll: false });
   };
 
+  const handleLogSingleMeal = async (mealType: MealType) => {
+    if (!planMeals.activePlan) return;
+
+    setLoggingMealType(mealType);
+
+    try {
+      await logFromPlanMutation.mutateAsync({
+        mode: 'add-meal',
+        date: dateStr,
+        planId: planMeals.activePlan.id,
+        mealType,
+      });
+      setLastAdded((prev) => ({ mealType, seq: (prev?.seq ?? 0) + 1 }));
+    } catch (error) {
+      toast.error((error as Error).message ?? 'Failed to log planned meal.');
+    } finally {
+      setLoggingMealType(null);
+    }
+  };
+
   // Handle favorite pill click — food or dish
   const handleFavoriteSelect = (item: FavoriteItem) => {
     if (item.type === 'dish') {
@@ -156,83 +218,111 @@ export function FoodLogContent() {
   };
 
   return (
-    <div className="grid min-w-0 lg:grid-cols-12 gap-6 lg:gap-8 items-start pt-6">
-      {/* Header */}
-      <div className="order-1 lg:order-none lg:col-span-8">
-        <PageHeader
-          overline="Food Log"
-          title="Meal Planner & Daily Intake"
-          subtitle={format(selectedDate, 'EEEE, MMMM d, yyyy')}
-          data-testid="food-log-heading"
-        >
-          <CreatePlanButton />
-          <CreateFoodButton />
-        </PageHeader>
+    <div className="grid min-w-0 items-start gap-6 pt-6 lg:grid-cols-12 lg:gap-8">
+      <div className="order-1 min-w-0 lg:order-0 lg:col-span-8">
+        <div className="space-y-6 lg:space-y-8">
+          {/* Header */}
+          <div>
+            <div className="hidden lg:block">
+              <PageHeader
+                overline="Food Log"
+                title="Meal Planner & Daily Intake"
+                subtitle={format(selectedDate, 'EEEE, MMMM d, yyyy')}
+                className="mb-0"
+                data-testid="food-log-heading"
+              >
+                <CreatePlanButton />
+                <CreateFoodButton />
+              </PageHeader>
+            </div>
 
-        {/* Mobile hero (reference-style) */}
-        <div className="sm:hidden -mt-2">
-          <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-            Today’s entry
-          </p>
-          <h1 className="mt-1 text-2xl font-headline font-extrabold tracking-tight text-foreground">
-            {mobileTitle}
-          </h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            {mobileSubtitle}
-          </p>
+            <div className="space-y-3 lg:hidden">
+              <div className="flex flex-wrap gap-2">
+                <CreatePlanButton />
+                <CreateFoodButton />
+              </div>
+              <div>
+                <h1 className="text-2xl font-headline font-extrabold tracking-tight text-foreground">
+                  {mobileTitle}
+                </h1>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  {mobileSubtitle}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {bannerPlan ? (
+            <MealPlanBanner
+              planName={bannerPlan.name}
+              dateStr={dateStr}
+              onLogAll={() => setLogMealsModalOpen(true)}
+            />
+          ) : null}
+
+          {/* Weekly calendar strip */}
+          <WeeklyCalendarStrip selectedDate={selectedDate} onDateChange={handleDateChange} />
+
+          <div className="lg:hidden">
+            <NutritionPulse
+              date={dateStr}
+              onAddFood={handleFavoriteSelect}
+              onQuickAddFood={(name) => foodSearch.setQuery(name)}
+              variant="mobile"
+            />
+          </div>
+
+          {/* Search row (desktop only) */}
+          <div className="hidden lg:block">
+            <FoodSearchField
+              state={foodSearch}
+              onQueryChange={foodSearch.setQuery}
+              onLoadMore={foodSearch.loadMore}
+              onSelect={handleSelect}
+              showCustomTab={true}
+              placeholder="Search for foods (e.g., 'apple', 'chicken breast')"
+            />
+          </div>
+
+          {/* Food log */}
+          <FoodLogClient
+            key={dateStr}
+            logs={logsQuery.data?.logs || []}
+            logsByMeal={logsQuery.data?.logsByMeal || {}}
+            totals={
+              logsQuery.data?.totals || {
+                calories: 0, protein: 0, carbs: 0, fat: 0,
+                fiber: 0, sugar: 0, sodium: 0,
+              }
+            }
+            isLoading={logsQuery.isLoading}
+            isPlanLoading={planMeals.isLoading}
+            selectedDate={selectedDate}
+            onDateChange={handleDateChange}
+            onDeleteLog={handleDeleteLog}
+            onDeleteDishGroup={handleDeleteDishGroup}
+            onEdit={handleEditLog}
+            lastAdded={lastAdded}
+            planMealsByMealType={planMeals.planMealsByMealType}
+            planId={planMeals.activePlan?.id}
+            loggingMealType={loggingMealType}
+            onLogPlanForMeal={handleLogSingleMeal}
+          />
         </div>
       </div>
 
-      {/* Weekly calendar strip */}
-      <div className="order-2 min-w-0 lg:order-none lg:col-span-8">
-        <WeeklyCalendarStrip selectedDate={selectedDate} onDateChange={handleDateChange} />
-      </div>
-
       {/* Nutrition Pulse — placed before meals on mobile */}
-      <div className="order-3 min-w-0 lg:order-none lg:col-start-9 lg:col-span-4 lg:row-start-1 lg:row-span-4">
+      <div className="hidden min-w-0 lg:order-0 lg:col-span-4 lg:block">
         <NutritionPulse
           date={dateStr}
           onAddFood={handleFavoriteSelect}
           onQuickAddFood={(name) => foodSearch.setQuery(name)}
+          variant="desktop"
         />
       </div>
 
-      {/* Search row (desktop + tablet) */}
-      <div className="order-4 lg:order-none lg:col-span-8 hidden sm:block">
-        <FoodSearchField
-          state={foodSearch}
-          onQueryChange={foodSearch.setQuery}
-          onLoadMore={foodSearch.loadMore}
-          onSelect={handleSelect}
-          showCustomTab={true}
-          placeholder="Search for foods (e.g., 'apple', 'chicken breast')"
-        />
-      </div>
-
-      {/* Food log */}
-      <div className="order-5 lg:order-none lg:col-span-8">
-        <FoodLogClient
-          key={dateStr}
-          logs={logsQuery.data?.logs || []}
-          logsByMeal={logsQuery.data?.logsByMeal || {}}
-          totals={
-            logsQuery.data?.totals || {
-              calories: 0, protein: 0, carbs: 0, fat: 0,
-              fiber: 0, sugar: 0, sodium: 0,
-            }
-          }
-          isLoading={logsQuery.isLoading}
-          selectedDate={selectedDate}
-          onDateChange={handleDateChange}
-          onDeleteLog={handleDeleteLog}
-          onDeleteDishGroup={handleDeleteDishGroup}
-          onEdit={handleEditLog}
-          lastAdded={lastAdded}
-        />
-      </div>
-
-      {/* Mobile FAB */}
-      <div className="sm:hidden">
+      {/* Mobile/tablet FAB */}
+      <div className="lg:hidden">
         <Button
           type="button"
           onClick={() => setMobileSearchOpen(true)}
@@ -245,11 +335,11 @@ export function FoodLogContent() {
         </Button>
       </div>
 
-      {/* Mobile search dialog: stacked dropdown lays out in-flow so modal height fits content (no min-h shell). */}
+      {/* Mobile/tablet search dialog: stacked dropdown lays out in-flow so modal height fits content (no min-h shell). */}
       <Dialog open={mobileSearchOpen} onOpenChange={setMobileSearchOpen}>
         <DialogContent
           className={[
-            'sm:hidden flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)]',
+            'lg:hidden flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)]',
             'flex-col gap-0 overflow-hidden rounded-2xl p-0',
           ].join(' ')}
         >
@@ -319,6 +409,22 @@ export function FoodLogContent() {
         onLogged={handleDishLogged}
         defaultDate={selectedDate}
       />
+
+      {planMeals.activePlan ? (
+        <LogMealsModal
+          open={logMealsModalOpen}
+          planName={planMeals.activePlan.name}
+          date={dateStr}
+          planId={planMeals.activePlan.id}
+          onClose={() => setLogMealsModalOpen(false)}
+          onSuccess={() => {
+            setLastAdded((prev) => ({
+              mealType: prev?.mealType ?? 'breakfast',
+              seq: (prev?.seq ?? 0) + 1,
+            }));
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/app/api/food-logs/from-plan/route.ts
+++ b/src/app/api/food-logs/from-plan/route.ts
@@ -1,0 +1,272 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq, gte, inArray, lt } from 'drizzle-orm';
+import { getCurrentUser } from '@/lib/session';
+import { db } from '@/server/db';
+import {
+  dietPlanMealItems,
+  dietPlanMeals,
+  dietPlans,
+  foodLogItems,
+  foodLogMeals,
+} from '@/server/db/schema';
+import { logFromPlanSchema, validateRequestBody } from '@/lib/api-validation';
+
+type MergeableMealType = typeof dietPlanMeals.$inferSelect.mealType;
+
+const PLAN_MEAL_HOURS: Record<MergeableMealType, number> = {
+  breakfast: 8,
+  morning_snack: 10,
+  lunch: 12,
+  afternoon_snack: 15,
+  dinner: 18,
+  evening_snack: 20,
+  pre_workout: 16,
+  post_workout: 19,
+  snack: 14,
+  other: 13,
+};
+
+function toDayWindow(date: string) {
+  return {
+    start: new Date(`${date}T00:00:00.000Z`),
+    end: new Date(`${date}T23:59:59.999Z`),
+  };
+}
+
+function getDbDayOfWeek(date: string) {
+  const jsDay = new Date(`${date}T12:00:00.000Z`).getUTCDay();
+  return jsDay === 0 ? 7 : jsDay;
+}
+
+function getMealTimestamp(date: string, mealType: MergeableMealType) {
+  const hour = PLAN_MEAL_HOURS[mealType] ?? PLAN_MEAL_HOURS.other;
+  return new Date(`${date}T${String(hour).padStart(2, '0')}:00:00.000Z`);
+}
+
+function createMergeKey(foodId: string, altMeasureId: string | null, mealType: string) {
+  return `${foodId}:${altMeasureId ?? 'null'}:${mealType}`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 },
+      );
+    }
+
+    const validation = await validateRequestBody(request, logFromPlanSchema);
+    if (!validation.success) {
+      return validation.response;
+    }
+
+    const { mode, date, planId } = validation.data;
+    const requestedMealType = mode === 'add-meal' ? validation.data.mealType : null;
+    const dayOfWeek = getDbDayOfWeek(date);
+    const { start, end } = toDayWindow(date);
+
+    const plan = await db.query.dietPlans.findFirst({
+      where: and(
+        eq(dietPlans.id, planId),
+        eq(dietPlans.clientId, user.id),
+        eq(dietPlans.status, 'active'),
+      ),
+    });
+
+    if (!plan) {
+      return NextResponse.json(
+        { success: false, error: 'Active plan not found' },
+        { status: 404 },
+      );
+    }
+
+    const planMealRows = await db
+      .select({
+        mealId: dietPlanMeals.id,
+        mealType: dietPlanMeals.mealType,
+        itemId: dietPlanMealItems.id,
+        foodId: dietPlanMealItems.foodId,
+        altMeasureId: dietPlanMealItems.altMeasureId,
+        quantity: dietPlanMealItems.quantity,
+      })
+      .from(dietPlanMeals)
+      .leftJoin(dietPlanMealItems, eq(dietPlanMealItems.groupId, dietPlanMeals.id))
+      .where(
+        and(
+          eq(dietPlanMeals.dietPlanId, planId),
+          eq(dietPlanMeals.dayOfWeek, dayOfWeek),
+          requestedMealType ? eq(dietPlanMeals.mealType, requestedMealType) : undefined,
+        ),
+      );
+
+    const coveredMealTypes = Array.from(
+      new Set(planMealRows.map((row) => row.mealType)),
+    );
+
+    if (coveredMealTypes.length === 0) {
+      return NextResponse.json({
+        success: true,
+        insertedCount: 0,
+        mergedCount: 0,
+        deletedCount: 0,
+      });
+    }
+
+    if (requestedMealType && !coveredMealTypes.includes(requestedMealType)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Selected meal type is not planned for this date',
+          field: 'mealType',
+        },
+        { status: 400 },
+      );
+    }
+
+    const planItems = planMealRows.filter((row) => row.itemId !== null);
+
+    const result = await db.transaction(async (tx) => {
+      let insertedCount = 0;
+      let mergedCount = 0;
+      let deletedCount = 0;
+
+      if (mode === 'replace-all') {
+        const mealsToDelete = await tx
+          .select({ id: foodLogMeals.id })
+          .from(foodLogMeals)
+          .where(
+            and(
+              eq(foodLogMeals.userId, user.id),
+              gte(foodLogMeals.consumedAt, start),
+              lt(foodLogMeals.consumedAt, end),
+              inArray(foodLogMeals.mealType, coveredMealTypes),
+            ),
+          );
+
+        if (mealsToDelete.length > 0) {
+          const mealIds = mealsToDelete.map((meal) => meal.id);
+          const itemsToDelete = await tx
+            .select({ id: foodLogItems.id })
+            .from(foodLogItems)
+            .where(inArray(foodLogItems.mealId, mealIds));
+
+          deletedCount = itemsToDelete.length;
+
+          await tx.delete(foodLogMeals).where(inArray(foodLogMeals.id, mealIds));
+        }
+      }
+
+      const existingItems = mode === 'replace-all'
+        ? []
+        : await tx
+            .select({
+              id: foodLogItems.id,
+              mealId: foodLogItems.mealId,
+              foodId: foodLogItems.foodId,
+              altMeasureId: foodLogItems.altMeasureId,
+              quantity: foodLogItems.quantity,
+              mealType: foodLogMeals.mealType,
+            })
+            .from(foodLogItems)
+            .innerJoin(foodLogMeals, eq(foodLogItems.mealId, foodLogMeals.id))
+            .where(
+              and(
+                eq(foodLogMeals.userId, user.id),
+                gte(foodLogMeals.consumedAt, start),
+                lt(foodLogMeals.consumedAt, end),
+                inArray(foodLogMeals.mealType, coveredMealTypes),
+              ),
+            );
+
+      const existingByKey = new Map(
+        existingItems.map((item) => [
+          createMergeKey(item.foodId, item.altMeasureId, item.mealType),
+          item,
+        ]),
+      );
+
+      const mealGroupByType = new Map<string, string>();
+
+      if (mode !== 'replace-all') {
+        const existingMeals = await tx
+          .select({
+            id: foodLogMeals.id,
+            mealType: foodLogMeals.mealType,
+            sourceDietPlanMealGroupId: foodLogMeals.sourceDietPlanMealGroupId,
+          })
+          .from(foodLogMeals)
+          .where(
+            and(
+              eq(foodLogMeals.userId, user.id),
+              gte(foodLogMeals.consumedAt, start),
+              lt(foodLogMeals.consumedAt, end),
+              inArray(foodLogMeals.mealType, coveredMealTypes),
+            ),
+          );
+
+        for (const meal of existingMeals) {
+          if (!mealGroupByType.has(meal.mealType)) {
+            mealGroupByType.set(meal.mealType, meal.id);
+          }
+        }
+      }
+
+      for (const row of planMealRows) {
+        if (!mealGroupByType.has(row.mealType)) {
+          const [newMeal] = await tx
+            .insert(foodLogMeals)
+            .values({
+              userId: user.id,
+              mealType: row.mealType,
+              consumedAt: getMealTimestamp(date, row.mealType),
+              sourceDietPlanMealGroupId: row.mealId,
+            })
+            .returning({ id: foodLogMeals.id });
+
+          mealGroupByType.set(row.mealType, newMeal.id);
+        }
+      }
+
+      for (const row of planItems) {
+        const mergeKey = createMergeKey(row.foodId!, row.altMeasureId, row.mealType);
+        const existing = existingByKey.get(mergeKey);
+
+        if (existing) {
+          await tx
+            .update(foodLogItems)
+            .set({
+              quantity: (Number(existing.quantity) + Number(row.quantity!)).toFixed(2),
+              updatedAt: new Date(),
+            })
+            .where(eq(foodLogItems.id, existing.id));
+          mergedCount += 1;
+          continue;
+        }
+
+        await tx.insert(foodLogItems).values({
+          mealId: mealGroupByType.get(row.mealType)!,
+          foodId: row.foodId!,
+          altMeasureId: row.altMeasureId,
+          quantity: Number(row.quantity!).toFixed(2),
+        });
+        insertedCount += 1;
+      }
+
+      return { insertedCount, mergedCount, deletedCount };
+    });
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    console.error('Error logging plan meals:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to log plan meals' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/food-log-client.tsx
+++ b/src/components/food-log-client.tsx
@@ -7,9 +7,11 @@ import { format } from 'date-fns';
 
 import { Loader2, Trash2, UtensilsCrossed, ChefHat, ChevronDown, MoreVertical, Sunrise, Sandwich, Moon } from 'lucide-react';
 import { FavoriteToggleButton } from '@/components/favorite-toggle-button';
+import { MealPlanAddon } from '@/components/food-log/meal-plan-addon';
 
 import { FoodLogEntry } from '@/types/food';
 import { MEAL_TYPE_ORDER, MEAL_TYPE_LABELS, MEAL_TYPE_COLORS, MEAL_DOT_COLORS, MACRO_BADGE_COLORS, type MealType } from '@/lib/nutrition-constants';
+import type { DietPlanMealDTO } from '@/server/services/diet-plan.service';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
@@ -28,12 +30,17 @@ interface FoodLogClientProps {
   logsByMeal: Record<string, FoodLogEntry[]>;
   totals: Totals;
   isLoading?: boolean;
+  isPlanLoading?: boolean;
   selectedDate: Date;
   onDateChange: (date: Date) => void;
   onDeleteLog: (logId: string) => Promise<void>;
   onDeleteDishGroup?: (dishLogGroupId: string) => Promise<void>;
   onEdit?: (log: FoodLogEntry) => void;
   lastAdded?: { mealType: MealType; seq: number } | null;
+  planMealsByMealType?: Partial<Record<MealType, DietPlanMealDTO>>;
+  planId?: string;
+  loggingMealType?: MealType | null;
+  onLogPlanForMeal?: (mealType: MealType) => void | Promise<void>;
 }
 
 
@@ -70,14 +77,47 @@ function isDishGroup(entry: GroupEntry): entry is { dishLogGroupId: string; dish
   return 'dishLogGroupId' in entry && 'items' in entry;
 }
 
+function buildFoodCountMap(foodIds: string[]) {
+  const counts = new Map<string, number>();
+
+  for (const foodId of foodIds) {
+    counts.set(foodId, (counts.get(foodId) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function mealLogsCoverPlan(mealLogs: FoodLogEntry[], planMeal?: DietPlanMealDTO) {
+  if (!planMeal || planMeal.items.length === 0 || mealLogs.length === 0) {
+    return false;
+  }
+
+  const plannedCounts = buildFoodCountMap(planMeal.items.map((item) => item.foodId));
+  const loggedCounts = buildFoodCountMap(mealLogs.map((log) => log.food.id));
+
+  for (const [foodId, plannedCount] of plannedCounts) {
+    if ((loggedCounts.get(foodId) ?? 0) < plannedCount) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export default function FoodLogClient({
   logs,
   logsByMeal,
+  selectedDate,
   onEdit,
   isLoading = false,
+  isPlanLoading = false,
   onDeleteLog,
   onDeleteDishGroup,
   lastAdded,
+  planMealsByMealType,
+  planId,
+  loggingMealType,
+  onLogPlanForMeal,
 }: FoodLogClientProps) {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
@@ -87,12 +127,16 @@ export default function FoodLogClient({
   const initialCollapseApplied = useRef(false);
 
   useEffect(() => {
-    if (isLoading || initialCollapseApplied.current) return;
+    if (isLoading || isPlanLoading || initialCollapseApplied.current) return;
     initialCollapseApplied.current = true;
     setCollapsedMeals(new Set(
-      MEAL_TYPE_ORDER.filter((mt) => !logsByMeal[mt] || logsByMeal[mt].length === 0)
+      MEAL_TYPE_ORDER.filter((mt) => {
+        const hasLogs = !!logsByMeal[mt] && logsByMeal[mt].length > 0;
+        const hasPlan = !!planMealsByMealType?.[mt];
+        return !hasLogs && !hasPlan;
+      })
     ));
-  }, [isLoading, logsByMeal]);
+  }, [isLoading, isPlanLoading, logsByMeal, planMealsByMealType]);
 
   useEffect(() => {
     if (!lastAdded) return;
@@ -160,6 +204,12 @@ export default function FoodLogClient({
     };
   }, []);
 
+  const visibleMealTypes = MEAL_TYPE_ORDER.filter((mealType) => {
+    const hasLogs = (logsByMeal[mealType] || []).length > 0;
+    const hasPlan = !!planMealsByMealType?.[mealType];
+    return hasLogs || hasPlan;
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16 text-muted-foreground">
@@ -184,9 +234,11 @@ export default function FoodLogClient({
       )}
 
       {/* Meal sections */}
-      {MEAL_TYPE_ORDER.map((mealType) => {
+      {visibleMealTypes.map((mealType) => {
         const mealLogs = logsByMeal[mealType] || [];
+        const planMeal = planMealsByMealType?.[mealType];
         const isEmpty = mealLogs.length === 0;
+        const shouldShowPlanAddon = !!planMeal && !!planId && !!onLogPlanForMeal && !mealLogsCoverPlan(mealLogs, planMeal);
 
         const mealTotals = mealLogs.reduce(
           (acc, log) => {
@@ -232,7 +284,7 @@ export default function FoodLogClient({
               onClick={toggleMeal}
               aria-expanded={!isMealCollapsed}
               data-testid={`meal-toggle-${mealType}`}
-              className={`w-full flex items-center justify-between px-5 py-4 text-left h-auto rounded-none group transition-colors hover:bg-secondary/40 ${!isMealCollapsed && !isEmpty ? 'border-b border-border/10' : ''}`}
+              className={`w-full flex items-center justify-between px-5 py-4 text-left h-auto rounded-none group transition-colors hover:bg-secondary/40 ${!isMealCollapsed && (!isEmpty || !!planMeal) ? 'border-b border-border/10' : ''}`}
             >
               <div>
                 <div className="flex items-center gap-2">
@@ -261,7 +313,7 @@ export default function FoodLogClient({
                   </span>
                 </div>
                 {latestLoggedTime && (
-                  <p className="text-xs text-muted-foreground mt-0.5 ml-[18px]">
+                  <p className="text-xs text-muted-foreground mt-0.5 ml-4.5">
                     Logged at {latestLoggedTime}
                   </p>
                 )}
@@ -282,26 +334,38 @@ export default function FoodLogClient({
             </Button>
 
             {!isMealCollapsed && isEmpty ? (
-              <div
-                className="flex items-center justify-center py-8 px-5"
-                data-testid={`meal-empty-placeholder-${mealType}`}
-              >
-                <div className="w-full sm:w-auto">
-                  <div className="sm:hidden rounded-2xl border border-dashed border-border/60 bg-muted/30 px-4 py-6 text-center">
-                    <p className="text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
-                      Plan {MEAL_TYPE_LABELS[mealType]}
-                    </p>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Nothing logged yet.
-                    </p>
-                  </div>
-                  <div className="hidden sm:flex flex-col items-center gap-2 text-center">
-                    <UtensilsCrossed className="h-6 w-6 text-muted-foreground/30" aria-hidden />
-                    <p className="text-sm text-muted-foreground">
-                      No {MEAL_TYPE_LABELS[mealType].toLowerCase()} logged
-                    </p>
+              <div>
+                <div
+                  className="flex items-center justify-center py-8 px-5"
+                  data-testid={`meal-empty-placeholder-${mealType}`}
+                >
+                  <div className="w-full sm:w-auto">
+                    <div className="sm:hidden rounded-2xl border border-dashed border-border/60 bg-muted/30 px-4 py-6 text-center">
+                      <p className="text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+                        Plan {MEAL_TYPE_LABELS[mealType]}
+                      </p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        Nothing logged yet.
+                      </p>
+                    </div>
+                    <div className="hidden sm:flex flex-col items-center gap-2 text-center">
+                      <UtensilsCrossed className="h-6 w-6 text-muted-foreground/30" aria-hidden />
+                      <p className="text-sm text-muted-foreground">
+                        No {MEAL_TYPE_LABELS[mealType].toLowerCase()} logged
+                      </p>
+                    </div>
                   </div>
                 </div>
+                {shouldShowPlanAddon ? (
+                  <MealPlanAddon
+                    mealType={mealType}
+                    planMeal={planMeal}
+                    planId={planId}
+                    date={selectedDate.toISOString()}
+                    isLogging={loggingMealType === mealType}
+                    onLogPlan={() => void onLogPlanForMeal(mealType)}
+                  />
+                ) : null}
               </div>
             ) : !isMealCollapsed ? (
               <div className="divide-y divide-border/10">
@@ -428,6 +492,16 @@ export default function FoodLogClient({
                     />
                   );
                 })}
+                {shouldShowPlanAddon ? (
+                  <MealPlanAddon
+                    mealType={mealType}
+                    planMeal={planMeal}
+                    planId={planId}
+                    date={selectedDate.toISOString()}
+                    isLogging={loggingMealType === mealType}
+                    onLogPlan={() => void onLogPlanForMeal(mealType)}
+                  />
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/components/food-log/log-meals-modal.tsx
+++ b/src/components/food-log/log-meals-modal.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useLogFromPlanMutation } from '@/queries/food-logs';
+
+interface LogMealsModalProps {
+  open: boolean;
+  planName: string;
+  date: string;
+  planId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function LogMealsModal({
+  open,
+  planName,
+  date,
+  planId,
+  onClose,
+  onSuccess,
+}: LogMealsModalProps) {
+  const mutation = useLogFromPlanMutation();
+  const [pendingMode, setPendingMode] = useState<'add-all' | 'replace-all' | null>(null);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (mutation.isPending) return;
+    if (!nextOpen) {
+      setPendingMode(null);
+      onClose();
+    }
+  };
+
+  const handleSubmit = async (mode: 'add-all' | 'replace-all') => {
+    setPendingMode(mode);
+
+    try {
+      await mutation.mutateAsync({ mode, date, planId });
+      onSuccess();
+      setPendingMode(null);
+      onClose();
+    } catch (error) {
+      setPendingMode(null);
+      toast.error((error as Error).message ?? 'Failed to log meals from plan.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md p-0" data-testid="log-meals-modal">
+        <DialogHeader>
+          <DialogTitle>Log meals from plan</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 px-6 pb-2">
+          <button
+            type="button"
+            onClick={() => handleSubmit('add-all')}
+            disabled={mutation.isPending}
+            data-testid="log-meals-add-btn"
+            className="w-full rounded-2xl border border-border/60 bg-muted/30 p-4 text-left transition-colors hover:border-primary/20 hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            <p className="text-sm font-medium text-foreground">Add to existing log</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Keeps your current entries and merges matching foods by meal and serving unit.
+            </p>
+            {pendingMode === 'add-all' ? (
+              <span className="mt-3 inline-flex items-center text-xs font-medium text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                Applying plan...
+              </span>
+            ) : null}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => handleSubmit('replace-all')}
+            disabled={mutation.isPending}
+            data-testid="log-meals-replace-btn"
+            className="w-full rounded-2xl border border-destructive/25 bg-destructive/5 p-4 text-left transition-colors hover:border-destructive/40 hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden />
+              <div>
+                <p className="text-sm font-medium text-foreground">Replace planned meal types</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Only meal types included in this day&apos;s plan are replaced. Unplanned meal types stay untouched.
+                </p>
+                {pendingMode === 'replace-all' ? (
+                  <span className="mt-3 inline-flex items-center text-xs font-medium text-muted-foreground">
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    Applying plan...
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div className="border-t border-border/70 bg-secondary/40 px-6 py-4">
+          <p className="text-center text-sm text-foreground">
+            Select one of the options above to continue.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/food-log/meal-plan-addon.tsx
+++ b/src/components/food-log/meal-plan-addon.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Loader2, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { MEAL_TYPE_LABELS, type MealType } from '@/lib/nutrition-constants';
+import type { DietPlanMealDTO } from '@/server/services/diet-plan.service';
+
+interface MealPlanAddonProps {
+  mealType: MealType;
+  planMeal: DietPlanMealDTO;
+  planId: string;
+  date: string;
+  isLogging: boolean;
+  onLogPlan: () => void;
+}
+
+export function MealPlanAddon({
+  mealType,
+  planMeal,
+  planId,
+  date,
+  isLogging,
+  onLogPlan,
+}: MealPlanAddonProps) {
+  if (planMeal.items.length === 0) {
+    return null;
+  }
+
+  const visibleItems = planMeal.items.slice(0, 3).map((item) => item.foodName);
+  const overflowCount = Math.max(planMeal.items.length - visibleItems.length, 0);
+
+  return (
+    <div
+      className="border-t border-border/10 bg-background px-5 py-4"
+      data-plan-id={planId}
+      data-plan-date={date}
+      data-testid={`meal-plan-addon-${mealType}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Sparkles className="h-3.5 w-3.5" aria-hidden />
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-foreground/80">
+              Plan for {MEAL_TYPE_LABELS[mealType]}
+            </p>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {visibleItems.join(' • ')}
+            {overflowCount > 0 ? ` • +${overflowCount} more` : ''}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 rounded-full border border-primary/10 bg-secondary px-3 text-xs font-semibold text-primary shadow-none hover:border-primary/25 hover:bg-primary/10 hover:text-primary dark:border-primary/12 dark:bg-secondary dark:hover:border-primary/35 dark:hover:bg-primary/18 dark:hover:text-primary"
+          onClick={onLogPlan}
+          disabled={isLogging}
+          data-testid={`log-plan-btn-${mealType}`}
+        >
+          {isLogging ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : null}
+          Log Plan
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/food-log/meal-plan-banner.tsx
+++ b/src/components/food-log/meal-plan-banner.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { format, parseISO } from 'date-fns';
+import { CircleAlert, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { usePlanBannerDismissed } from '@/hooks/use-plan-banner-dismissed';
+
+interface MealPlanBannerProps {
+  planName: string;
+  dateStr: string;
+  onLogAll: () => void;
+}
+
+export function MealPlanBanner({ planName, dateStr, onLogAll }: MealPlanBannerProps) {
+  const { isDismissed, dismiss } = usePlanBannerDismissed(dateStr);
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const formattedDate = format(parseISO(dateStr), 'EEEE, MMM d');
+
+  return (
+    <div
+      className="rounded-4xl border border-sky-200 bg-[linear-gradient(180deg,#eef6ff_0%,#e6f1ff_100%)] px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] sm:rounded-[22px] sm:px-5 sm:py-3 dark:border-sky-950/80 dark:bg-[linear-gradient(180deg,rgba(10,31,58,0.96)_0%,rgba(14,40,73,0.94)_100%)] dark:shadow-[0_1px_2px_rgba(2,6,23,0.35)]"
+      data-testid="meal-plan-banner"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+        <div className="flex min-w-0 items-start gap-2.5 sm:gap-3">
+          <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600/12 text-blue-600 sm:h-8 sm:w-8 dark:bg-blue-300/10 dark:text-sky-200">
+            <CircleAlert className="h-3.5 w-3.5 sm:h-4 sm:w-4" aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold leading-none text-blue-800 sm:text-sm dark:text-sky-100">
+              Meal plan ready
+            </p>
+            <p className="mt-1 text-xs leading-[1.35rem] text-blue-700 sm:text-sm sm:leading-5 dark:text-sky-200/85">
+              Your pre-defined {planName.toLowerCase()} strategy is ready for {formattedDate}. You can log all planned meals at once to save time.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-1.5 pl-9 sm:gap-2 sm:pl-0">
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 rounded-lg bg-blue-600 px-2.5 text-[11px] font-semibold text-white shadow-[0_6px_14px_rgba(37,99,235,0.16)] hover:bg-blue-700 sm:h-8 sm:px-3 sm:text-xs dark:bg-blue-500 dark:text-slate-950 dark:shadow-[0_8px_18px_rgba(2,6,23,0.28)] dark:hover:bg-blue-400"
+            onClick={onLogAll}
+            data-testid="log-all-meals-btn"
+          >
+            <span className="sm:hidden">Log meals</span>
+            <span className="hidden sm:inline">Log all meals</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="h-8 w-8 shrink-0 rounded-full text-blue-500 hover:bg-blue-600/10 hover:text-blue-700 sm:h-9 sm:w-9 dark:text-sky-300 dark:hover:bg-white/8 dark:hover:text-sky-100"
+            onClick={dismiss}
+            data-testid="meal-plan-banner-dismiss"
+            aria-label="Dismiss meal plan banner"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/food-log/nutrition-pulse.tsx
+++ b/src/components/food-log/nutrition-pulse.tsx
@@ -14,9 +14,15 @@ interface NutritionPulseProps {
   date: string;
   onAddFood: (item: FavoriteItem) => void;
   onQuickAddFood?: (name: string) => void;
+  variant?: 'mobile' | 'desktop';
 }
 
-export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPulseProps) {
+export function NutritionPulse({
+  date,
+  onAddFood,
+  onQuickAddFood,
+  variant = 'desktop',
+}: NutritionPulseProps) {
   const { data, isLoading } = useNutritionSummaryQuery(date);
   const { data: logsData } = useFoodLogsQuery(date);
   const { data: topFavsData } = useFavoritesTopQuery();
@@ -105,18 +111,17 @@ export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPul
     ? [...new Map(logsData.logs.map((l) => [l.food.id, l.food])).values()].slice(0, 5)
     : [];
 
-  return (
-    <>
-      <div data-testid="nutrition-pulse">
-        {/* Mobile summary card */}
-        <div className="sm:hidden w-full min-w-0 max-w-full overflow-x-clip rounded-3xl border border-border/30 bg-muted/70 p-4 shadow-sm dark:bg-secondary">
+  if (variant === 'mobile') {
+    return (
+      <div data-testid="nutrition-pulse-mobile">
+        <div className="w-full min-w-0 max-w-full overflow-x-clip rounded-3xl border border-border/30 bg-muted/70 p-4 shadow-sm dark:bg-secondary">
           <div className="flex min-w-0 items-start justify-between gap-3">
             <div className="min-w-0 flex-1 pr-1">
               <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
                 Energy deficit
               </p>
               <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                <span className="max-w-full min-w-0 break-words text-2xl font-headline font-extrabold tabular-nums text-foreground">
+                <span className="max-w-full min-w-0 wrap-break-word text-2xl font-headline font-extrabold tabular-nums text-foreground">
                   {logTotals?.calories ?? 0}
                 </span>
                 <span className="text-xs text-muted-foreground tabular-nums">
@@ -125,7 +130,6 @@ export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPul
               </div>
             </div>
 
-            {/* Donut percent */}
             {(() => {
               const mobileSize = 52;
               const mobileStroke = 7;
@@ -135,7 +139,6 @@ export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPul
               return (
                 <div className="relative shrink-0" style={{ width: mobileSize, height: mobileSize }}>
                   <svg width={mobileSize} height={mobileSize} viewBox={`0 0 ${mobileSize} ${mobileSize}`} className="-rotate-90" aria-hidden>
-                    {/* Use var(--*) — theme colors are OKLCH; hsl(var(--*)) is invalid and hides strokes */}
                     <circle
                       cx={mobileSize / 2}
                       cy={mobileSize / 2}
@@ -180,7 +183,7 @@ export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPul
                       {consumed}g
                     </span>
                   </div>
-                  <div className="mt-2 h-2 rounded-full bg-black/10 dark:bg-border overflow-hidden">
+                  <div className="mt-2 h-2 overflow-hidden rounded-full bg-black/10 dark:bg-border">
                     <div
                       className={`h-full rounded-full transition-all duration-500 ${MACRO_COLORS[key]}`}
                       style={{ width: `${macroPct}%` }}
@@ -191,11 +194,16 @@ export function NutritionPulse({ date, onAddFood, onQuickAddFood }: NutritionPul
             })}
           </div>
         </div>
+      </div>
+    );
+  }
 
-        {/* Desktop sidebar card */}
+  return (
+    <>
+      <div data-testid="nutrition-pulse">
         <div
           className={[
-            'hidden sm:block bg-[#C1F0B1] rounded-[2rem] p-8 sticky top-24 overflow-hidden relative',
+            'bg-[#C1F0B1] rounded-[2rem] p-8 sticky top-24 overflow-hidden',
             'dark:bg-secondary dark:border dark:border-primary/30',
             '[--pulse-fill:var(--green-dark)] [--pulse-track:#aee39d]',
             'dark:[--pulse-fill:var(--primary)] dark:[--pulse-track:var(--border)]',

--- a/src/hooks/use-plan-banner-dismissed.ts
+++ b/src/hooks/use-plan-banner-dismissed.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+function getDismissKey(dateStr: string) {
+  return `vitalis-plan-banner-${dateStr}`;
+}
+
+function readDismissed(dateStr: string) {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(getDismissKey(dateStr)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function usePlanBannerDismissed(dateStr: string) {
+  const [isDismissed, setIsDismissed] = useState(() => readDismissed(dateStr));
+
+  useEffect(() => {
+    setIsDismissed(readDismissed(dateStr));
+  }, [dateStr]);
+
+  const dismiss = useCallback(() => {
+    setIsDismissed(true);
+
+    if (typeof window === 'undefined') return;
+
+    try {
+      window.localStorage.setItem(getDismissKey(dateStr), 'true');
+    } catch {
+      // Ignore storage failures and keep local state.
+    }
+  }, [dateStr]);
+
+  return { isDismissed, dismiss };
+}

--- a/src/lib/api-validation.ts
+++ b/src/lib/api-validation.ts
@@ -215,6 +215,25 @@ export const copyDaySchema = z.object({
   toDay: dayOfWeekSchema,
 });
 
+export const logFromPlanSchema = z.discriminatedUnion('mode', [
+  z.object({
+    mode: z.literal('replace-all'),
+    date: dateSchema,
+    planId: z.string().uuid('planId must be a valid UUID'),
+  }),
+  z.object({
+    mode: z.literal('add-all'),
+    date: dateSchema,
+    planId: z.string().uuid('planId must be a valid UUID'),
+  }),
+  z.object({
+    mode: z.literal('add-meal'),
+    date: dateSchema,
+    planId: z.string().uuid('planId must be a valid UUID'),
+    mealType: mealTypeSchema,
+  }),
+]);
+
 // ============================================
 // TRANSFORMATION HELPERS
 // ============================================

--- a/src/queries/diet-plans.ts
+++ b/src/queries/diet-plans.ts
@@ -1,4 +1,6 @@
+import { useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { MEAL_TYPE_ORDER, type MealType } from '@/lib/nutrition-constants'
 import type { DietPlanDTO, DietPlanMealDTO, MealItemDTO, NutritionGoalDefaults } from '@/server/services/diet-plan.service'
 
 // ============================================
@@ -21,6 +23,15 @@ export interface DietPlansResponse {
 
 export interface DietPlanMealsResponse {
   meals: DietPlanMealDTO[]
+}
+
+function getDbDayOfWeek(dateStr: string) {
+  const jsDay = new Date(`${dateStr}T12:00:00.000Z`).getUTCDay()
+  return jsDay === 0 ? 7 : jsDay
+}
+
+function isMealType(value: string): value is MealType {
+  return (MEAL_TYPE_ORDER as readonly string[]).includes(value)
 }
 
 // ============================================
@@ -54,6 +65,35 @@ export function useDietPlanMealsQuery(planId: string | null) {
       return res.json()
     },
   })
+}
+
+export function usePlanMealsForDate(dateStr: string) {
+  const plansQuery = useDietPlansQuery()
+
+  const activePlan = useMemo(
+    () => plansQuery.data?.plans.find((plan) => plan.status === 'active') ?? null,
+    [plansQuery.data?.plans],
+  )
+
+  const mealsQuery = useDietPlanMealsQuery(activePlan?.id ?? null)
+
+  const planMealsByMealType = useMemo<Partial<Record<MealType, DietPlanMealDTO>>>(() => {
+    if (!mealsQuery.data?.meals?.length) return {}
+
+    const dayOfWeek = getDbDayOfWeek(dateStr)
+    const entries = mealsQuery.data.meals
+      .filter((meal) => meal.dayOfWeek === dayOfWeek && isMealType(meal.mealType))
+      .map((meal) => [meal.mealType, meal] as const)
+
+    return Object.fromEntries(entries) as Partial<Record<MealType, DietPlanMealDTO>>
+  }, [dateStr, mealsQuery.data?.meals])
+
+  return {
+    activePlan,
+    planMealsByMealType,
+    hasPlanForDay: Object.keys(planMealsByMealType).length > 0,
+    isLoading: plansQuery.isLoading || (!!activePlan && mealsQuery.isLoading),
+  }
 }
 
 // ============================================

--- a/src/queries/food-logs.ts
+++ b/src/queries/food-logs.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { FoodLogEntry } from '@/types/food'
+import type { MealType } from '@/lib/nutrition-constants'
 
 interface FoodLogsResponse {
   logs: FoodLogEntry[]
@@ -150,6 +151,45 @@ export function useDeleteFoodLogMutation() {
       // Also invalidate analytics
       queryClient.invalidateQueries({ queryKey: ['analytics'] })
       // Invalidate nutrition summary so sidebar updates
+      queryClient.invalidateQueries({ queryKey: ['nutrition-summary'] })
+    },
+  })
+}
+
+type LogFromPlanRequest =
+  | { mode: 'replace-all'; date: string; planId: string }
+  | { mode: 'add-all'; date: string; planId: string }
+  | { mode: 'add-meal'; date: string; planId: string; mealType: MealType }
+
+interface LogFromPlanResponse {
+  success: boolean
+  insertedCount: number
+  mergedCount: number
+  deletedCount: number
+}
+
+export function useLogFromPlanMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: LogFromPlanRequest): Promise<LogFromPlanResponse> => {
+      const response = await fetch('/api/food-logs/from-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to log meals from plan')
+      }
+
+      return payload
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['food-logs'] })
+      queryClient.invalidateQueries({ queryKey: ['analytics'] })
       queryClient.invalidateQueries({ queryKey: ['nutrition-summary'] })
     },
   })


### PR DESCRIPTION
- Add new API route for logging meals from a diet plan.
- Create a modal for logging meals with options to add or replace meals.
- Introduce a meal plan banner to notify users of available meal plans.
- Enhance food log client to display meal plan information and allow logging.
- Implement hooks for managing meal plan banner dismissal state.
- Update validation schema to support logging meals from a plan.
- Add query for fetching meal plans based on the selected date.
- Refactor food log queries to include logging from plans functionality.