### PR TITLE
fix(e2e): harden runner and stabilize food-log specs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,17 +61,20 @@ jobs:
           NUTRITIONIX_APP_ID: test_app_id
           NUTRITIONIX_API_KEY: test_api_key
           USE_MOCK_NUTRITIONIX: 'true'
+          USE_MOCK_FATSECRET: 'true'
+          FATSECRET_CONSUMER_KEY: test_consumer_key
+          FATSECRET_CONSUMER_SECRET: test_consumer_secret
           NODE_ENV: test
           PORT: '3014'
         run: |
-          # Start dev server in background on port 3014
-          npm run dev -- --port 3014 &
+          # Start dev server in background on port 3014 (load .env.test for mocks + port)
+          npx dotenv -e .env.test -o -- npm run dev -- --port 3014 &
           DEV_PID=$!
           
           # Wait for server to be ready
           echo "Waiting for dev server to start on port 3014..."
           for i in {1..60}; do
-            if curl -s http://localhost:3014/api/auth/session > /dev/null 2>&1; then
+            if curl -sf http://localhost:3014/login > /dev/null 2>&1; then
               echo "Server is ready!"
               break
             fi
@@ -80,7 +83,7 @@ jobs:
           
           # Run seed
           echo "Seeding database..."
-          npx tsx src/server/db/seed.ts
+          npx dotenv -e .env.test -o -- npx tsx src/server/db/seed.ts
 
       - name: Run E2E tests
         env:
@@ -92,11 +95,14 @@ jobs:
           NUTRITIONIX_APP_ID: test_app_id
           NUTRITIONIX_API_KEY: test_api_key
           USE_MOCK_NUTRITIONIX: 'true'
+          USE_MOCK_FATSECRET: 'true'
+          FATSECRET_CONSUMER_KEY: test_consumer_key
+          FATSECRET_CONSUMER_SECRET: test_consumer_secret
           NODE_ENV: test
           PORT: '3014'
           PLAYWRIGHT_TEST_BASE_URL: http://localhost:3014
           CI: true
-        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/2
+        run: npx dotenv -e .env.test -o -- npx playwright test --project=chromium --shard=${{ matrix.shard }}/2
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/e2e/004-food-search-field.spec.ts
+++ b/e2e/004-food-search-field.spec.ts
@@ -9,6 +9,7 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { typeLandingFoodSearch } from './helpers/food-search';
 import { seedUsers } from './fixtures/test-data';
 import { LoginPage } from './pages/login.page';
 
@@ -126,10 +127,7 @@ test.describe('004 US2: Anonymous Landing Page Search', () => {
     await page.goto('/');
     await expect(page.getByTestId('landing-search-section')).toBeVisible();
 
-    const searchInput = page.getByTestId('food-search-input');
-    await searchInput.click();
-    await searchInput.fill('apple');
-    await page.waitForTimeout(600);
+    await typeLandingFoodSearch(page, 'apple');
 
     // Should show Common and Branded tabs, no Custom tab
     await expect(page.getByTestId('tab-common')).toBeVisible();
@@ -145,17 +143,14 @@ test.describe('004 US2: Anonymous Landing Page Search', () => {
 
     await page.goto('/');
 
-    const searchInput = page.getByTestId('food-search-input');
-    await searchInput.click();
-    await searchInput.fill('apple');
-    await page.waitForTimeout(600);
+    await typeLandingFoodSearch(page, 'apple');
 
     const firstResult = page.getByTestId('food-result-item').first();
     await expect(firstResult).toBeVisible({ timeout: 5000 });
     await firstResult.click();
 
     // Should navigate to /foods/:id
-    await expect(page).toHaveURL(/\/foods\//, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/foods\//, { timeout: 15000 });
 
     await context.close();
   });
@@ -166,16 +161,13 @@ test.describe('004 US2: Anonymous Landing Page Search', () => {
 
     await page.goto('/');
 
-    const searchInput = page.getByTestId('food-search-input');
-    await searchInput.click();
-    await searchInput.fill('apple');
-    await page.waitForTimeout(600);
+    await typeLandingFoodSearch(page, 'apple');
 
     const firstResult = page.getByTestId('food-result-item').first();
     await expect(firstResult).toBeVisible({ timeout: 5000 });
     await firstResult.click();
 
-    await expect(page).toHaveURL(/\/foods\//, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/foods\//, { timeout: 15000 });
     await expect(page.locator('h1')).not.toBeEmpty({ timeout: 10000 });
 
     await context.close();
@@ -187,15 +179,13 @@ test.describe('004 US2: Anonymous Landing Page Search', () => {
 
     await page.goto('/');
 
-    const searchInput = page.getByTestId('food-search-input');
-    await searchInput.click();
-    await searchInput.fill('apple');
-    await page.waitForTimeout(600);
+    await typeLandingFoodSearch(page, 'apple');
 
     const firstResult = page.getByTestId('food-result-item').first();
+    await expect(firstResult).toBeVisible({ timeout: 5000 });
     await firstResult.click();
 
-    await expect(page).toHaveURL(/\/foods\//, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/foods\//, { timeout: 15000 });
     // Page contains nutrition section
     await expect(page.getByText(/Nutrition per 100g/i)).toBeVisible({ timeout: 10000 });
     await expect(page.getByText(/Calories/i)).toBeVisible();

--- a/e2e/006-food-log-redesign.spec.ts
+++ b/e2e/006-food-log-redesign.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type TestInfo } from '@playwright/test';
-import { AUTH_FILES, seedUsers, testUser } from './fixtures/test-data';
+import { deleteAllPlansViaApi, deletePlanViaApi } from './helpers/diet-plans';
+import { AUTH_FILES, testUser } from './fixtures/test-data';
 import { FoodLogPage } from './pages/food-log.page';
 import { LoginPage } from './pages/login.page';
 import { format, addDays, startOfWeek, subDays } from 'date-fns';
@@ -75,30 +76,10 @@ test.describe('006: Food Log Screen Redesign', () => {
     expect(res.ok()).toBeTruthy();
   }
 
-  async function deletePlanViaApi(page: import('@playwright/test').Page, planId: string) {
-    await page.request.delete(`/api/diet-plans/${planId}`);
-  }
-
-  async function deleteAllPlansViaApi(page: import('@playwright/test').Page) {
-    const res = await page.request.get('/api/diet-plans');
-    if (!res.ok()) return;
-    const body = await res.json();
-    for (const plan of (body.plans ?? []) as Array<{ id: string }>) {
-      await deletePlanViaApi(page, plan.id);
-    }
-  }
-
   async function loginAsTestUser(page: import('@playwright/test').Page) {
     const loginPage = new LoginPage(page);
     await loginPage.goto();
     await loginPage.login(testUser.email, testUser.password);
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
-  }
-
-  async function loginAsFreshUser(page: import('@playwright/test').Page) {
-    const loginPage = new LoginPage(page);
-    await loginPage.goto();
-    await loginPage.login(seedUsers.professional1.email, seedUsers.professional1.password);
     await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
   }
 
@@ -195,6 +176,18 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
   });
 
+  test.describe('Nutrition Pulse Sidebar — fresh professional user', () => {
+    test.use({ storageState: AUTH_FILES.professional1 });
+
+    test('sidebar renders for fresh user with no goals', async ({ page }) => {
+      const foodLogPage = new FoodLogPage(page);
+      await foodLogPage.goto();
+
+      await expect(foodLogPage.nutritionPulse).toBeVisible();
+      await expect(foodLogPage.pulseCaloriesRemaining).toBeVisible();
+    });
+  });
+
   test.describe('Nutrition Pulse Sidebar', () => {
     test('sidebar is visible', async ({ page }) => {
       await loginAsTestUser(page);
@@ -223,16 +216,6 @@ test.describe('006: Food Log Screen Redesign', () => {
       await expect(foodLogPage.pulseMacroProtein).toBeVisible();
       await expect(foodLogPage.pulseMacroCarbs).toBeVisible();
       await expect(foodLogPage.pulseMacroFat).toBeVisible();
-    });
-
-    test('sidebar renders for fresh user with no goals', async ({ page }) => {
-      await loginAsFreshUser(page);
-      const foodLogPage = new FoodLogPage(page);
-      await foodLogPage.goto();
-
-      // Should still render without crashing
-      await expect(foodLogPage.nutritionPulse).toBeVisible();
-      await expect(foodLogPage.pulseCaloriesRemaining).toBeVisible();
     });
 
     test('remaining calories decreases after logging food', async ({ page }) => {
@@ -265,6 +248,7 @@ test.describe('006: Food Log Screen Redesign', () => {
   });
 
   test.describe('Meal Card Design', () => {
+    test.use({ storageState: AUTH_FILES.professional1 });
     test('renders only meal sections that have logs or a plan', async ({ page }) => {
       await loginAsTestUser(page);
       const foodLogPage = new FoodLogPage(page);
@@ -314,7 +298,7 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
 
     test('empty meal placeholders appear for unlogged planned meals', async ({ page }) => {
-      await loginAsFreshUser(page);
+      await deleteAllPlansViaApi(page);
       const foodLogPage = new FoodLogPage(page);
       const today = new Date();
       const dayOfWeek = getDbDayOfWeek(today);
@@ -358,6 +342,7 @@ test.describe('006: Food Log Screen Redesign', () => {
   });
 
   test.describe('Meal Footer Summary', () => {
+    test.use({ storageState: AUTH_FILES.professional1 });
     test('logged meal sections show footer with calories and macros', async ({ page }) => {
       await loginAsTestUser(page);
       const foodLogPage = new FoodLogPage(page);
@@ -427,7 +412,7 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
 
     test('empty meal section does not show footer summary', async ({ page }) => {
-      await loginAsFreshUser(page);
+      await deleteAllPlansViaApi(page);
       const today = new Date();
       const planId = await createPlanViaApi(page, {
         name: `E2E Footer Empty Plan ${Date.now()}`,
@@ -703,6 +688,7 @@ test.describe('006: Food Log Screen Redesign', () => {
   });
 
   test.describe('Empty Meal Quick Add', () => {
+    test.use({ storageState: AUTH_FILES.professional1 });
     test.describe.configure({ mode: 'serial' });
 
     async function createPlanWithMeal(
@@ -734,7 +720,6 @@ test.describe('006: Food Log Screen Redesign', () => {
     }
 
     test('empty meal section renders a "Log {meal}" action button', async ({ page }) => {
-      await loginAsFreshUser(page);
       await deleteAllPlansViaApi(page);
       const planId = await createPlanWithMeal(page, 'breakfast');
 
@@ -755,7 +740,6 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
 
     test('clicking empty-state action opens search dialog targeted at that meal', async ({ page }) => {
-      await loginAsFreshUser(page);
       await deleteAllPlansViaApi(page);
       const planId = await createPlanWithMeal(page, 'lunch');
 
@@ -779,7 +763,6 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
 
     test('selecting a food from the empty-state flow pre-fills the meal type', async ({ page }) => {
-      await loginAsFreshUser(page);
       await deleteAllPlansViaApi(page);
       const planId = await createPlanWithMeal(page, 'dinner');
 
@@ -810,7 +793,6 @@ test.describe('006: Food Log Screen Redesign', () => {
     });
 
     test('dismissing the dialog clears the pending meal target', async ({ page }) => {
-      await loginAsFreshUser(page);
       await deleteAllPlansViaApi(page);
       const planId = await createPlanWithMeal(page, 'breakfast');
 

--- a/e2e/007-custom-dishes-and-favorites.spec.ts
+++ b/e2e/007-custom-dishes-and-favorites.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { seedUsers, testUser } from './fixtures/test-data';
+import { AUTH_FILES, seedUsers, testUser } from './fixtures/test-data';
 import { LoginPage } from './pages/login.page';
 
 // testUser = user.weight-loss@example.com — has seeded dishes & favorites
@@ -13,6 +13,8 @@ async function loginAs(page: import('@playwright/test').Page, email: string, pas
 
 const login = (page: import('@playwright/test').Page) =>
   loginAs(page, testUser.email, testUser.password);
+
+test.use({ storageState: AUTH_FILES.testUser });
 
 // ────────────────────────────────────────────────────────────────────────────
 // My Foods page

--- a/e2e/013-meal-planner.spec.ts
+++ b/e2e/013-meal-planner.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { deleteAllPlansViaApi, deletePlanViaApi } from './helpers/diet-plans';
 import { testUser, mealPlannerSeedData, AUTH_FILES } from './fixtures/test-data';
 import { LoginPage } from './pages/login.page';
 import { MealPlannerPage } from './pages/meal-planner.page';
@@ -36,19 +37,6 @@ async function createPlanViaApi(page: Page, data: CreatePlanInput): Promise<stri
   expect(res.ok()).toBeTruthy();
   const body = await res.json();
   return body.plan.id as string;
-}
-
-async function deletePlanViaApi(page: Page, planId: string): Promise<void> {
-  await page.request.delete(`/api/diet-plans/${planId}`);
-}
-
-async function deleteAllPlansViaApi(page: Page): Promise<void> {
-  const res = await page.request.get('/api/diet-plans');
-  if (!res.ok()) return;
-  const body = await res.json();
-  for (const plan of (body.plans ?? []) as Array<{ id: string }>) {
-    await deletePlanViaApi(page, plan.id);
-  }
 }
 
 async function createMealViaApi(

--- a/e2e/helpers/diet-plans.ts
+++ b/e2e/helpers/diet-plans.ts
@@ -1,0 +1,20 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Plan deletes can cascade many rows; allow extra time under parallel E2E load. */
+const API_DELETE_TIMEOUT_MS = 30_000;
+
+export async function deletePlanViaApi(page: Page, planId: string): Promise<void> {
+  const res = await page.request.delete(`/api/diet-plans/${planId}`, {
+    timeout: API_DELETE_TIMEOUT_MS,
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+export async function deleteAllPlansViaApi(page: Page): Promise<void> {
+  const res = await page.request.get('/api/diet-plans');
+  if (!res.ok()) return;
+  const body = await res.json();
+  for (const plan of (body.plans ?? []) as Array<{ id: string }>) {
+    await deletePlanViaApi(page, plan.id);
+  }
+}

--- a/e2e/helpers/food-search.ts
+++ b/e2e/helpers/food-search.ts
@@ -1,0 +1,25 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Wait for debounced search + dropdown results (landing or in-app). */
+export async function typeFoodSearch(page: Page, query: string) {
+  const searchInput = page.getByTestId('food-search-input');
+  await searchInput.click();
+  await searchInput.fill(query);
+  await expect(page.getByTestId('food-search-dropdown')).toBeVisible({ timeout: 5000 });
+
+  if (query.length >= 3) {
+    await Promise.race([
+      page.getByTestId('food-result-item').first().waitFor({ state: 'visible', timeout: 7000 }),
+      page.getByTestId('search-empty').waitFor({ state: 'visible', timeout: 7000 }),
+      page.getByTestId('search-error').waitFor({ state: 'visible', timeout: 7000 }),
+    ]);
+  } else {
+    await page.waitForTimeout(250);
+  }
+}
+
+/** Landing search sits below the fold; scroll before interacting. */
+export async function typeLandingFoodSearch(page: Page, query: string) {
+  await page.getByTestId('landing-search-section').scrollIntoViewIfNeeded();
+  await typeFoodSearch(page, query);
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,8 @@ import { defineConfig, devices } from '@playwright/test';
 // Test server runs on port 3014 to avoid conflicts with dev server on 3000
 const TEST_PORT = process.env.PORT || '3014';
 const TEST_URL = process.env.PLAYWRIGHT_TEST_BASE_URL || `http://localhost:${TEST_PORT}`;
+/** Set by scripts/run-e2e.sh — server is already running; do not start webServer. */
+const MANAGED_BY_E2E_SCRIPT = process.env.PLAYWRIGHT_MANAGED_SERVER === '1';
 
 export default defineConfig({
   testDir: './e2e',
@@ -10,7 +12,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,
   maxFailures: process.env.CI ? 2 : undefined,
-  workers: process.env.CI ? 6 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'html',
   timeout: 60000,
   use: {
@@ -39,12 +41,14 @@ export default defineConfig({
       dependencies: ['setup'],
     },
   ],
-  // When running via run-e2e.sh, the script manages the server
-  // When running directly or in CI, start a server
-  webServer: {
-    command: `npx dotenv -e .env.test -o -- npm run dev -- --port ${TEST_PORT}`,
-    url: TEST_URL,
-    reuseExistingServer: true, // Reuse if script already started one
-    timeout: 120 * 1000,
-  },
+  // When running via run-e2e.sh, the script manages the server (see PLAYWRIGHT_MANAGED_SERVER).
+  // When running directly or in CI, start a server.
+  webServer: MANAGED_BY_E2E_SCRIPT
+    ? undefined
+    : {
+        command: `npx dotenv -e .env.test -o -- npm run dev -- --port ${TEST_PORT}`,
+        url: TEST_URL,
+        reuseExistingServer: true,
+        timeout: 120 * 1000,
+      },
 });

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -116,9 +116,7 @@ cleanup() {
         wait $DEV_PID 2>/dev/null || true
     fi
     
-    # Kill any remaining next dev processes on test port
-    pkill -f "next dev.*--port $TEST_PORT" 2>/dev/null || true
-    pkill -f "next start.*--port $TEST_PORT" 2>/dev/null || true
+    kill_port "$TEST_PORT"
     
     # Remove Next.js lock file if exists
     rm -rf .next/dev/lock 2>/dev/null || true
@@ -145,17 +143,65 @@ check_docker() {
     fi
 }
 
+# Free the test port (pkill alone is unreliable on Windows Git Bash).
+kill_port() {
+    local port=$1
+
+    # Windows: PowerShell is the most reliable way to stop listeners on a port.
+    if command -v powershell.exe >/dev/null 2>&1; then
+        powershell.exe -NoProfile -Command "
+            \$conns = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+            if (\$conns) {
+                \$conns | ForEach-Object {
+                    Stop-Process -Id \$_.OwningProcess -Force -ErrorAction SilentlyContinue
+                }
+            }
+        " >/dev/null 2>&1 || true
+    fi
+
+    if command -v netstat >/dev/null 2>&1 && command -v taskkill >/dev/null 2>&1; then
+        local line pid
+        while IFS= read -r line; do
+            pid=$(echo "$line" | awk '{print $NF}')
+            if [ -n "$pid" ] && [ "$pid" != "0" ]; then
+                taskkill //F //PID "$pid" >/dev/null 2>&1 || true
+            fi
+        done < <(netstat -ano 2>/dev/null | grep LISTENING | grep ":$port" || true)
+    fi
+
+    if command -v lsof >/dev/null 2>&1; then
+        local pid
+        for pid in $(lsof -ti ":$port" 2>/dev/null || true); do
+            kill -9 "$pid" 2>/dev/null || true
+        done
+    fi
+
+    pkill -f "next dev.*--port $port" 2>/dev/null || true
+    pkill -f "next start.*--port $port" 2>/dev/null || true
+
+    sleep 2
+}
+
+port_is_listening() {
+    local port=$1
+    if command -v powershell.exe >/dev/null 2>&1; then
+        local count
+        count=$(powershell.exe -NoProfile -Command "@(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).Count" 2>/dev/null || echo "0")
+        [ "${count:-0}" != "0" ]
+        return $?
+    fi
+    netstat -ano 2>/dev/null | grep LISTENING | grep -q ":$port"
+}
+
 # Kill any existing processes that might conflict
 kill_existing() {
     log_info "Checking for existing processes..."
-    
-    # Kill any next dev on test port
-    pkill -f "next dev.*--port $TEST_PORT" 2>/dev/null || true
-    
+
+    kill_port "$TEST_PORT"
+
     # Remove lock file
     rm -rf .next/dev/lock 2>/dev/null || true
-    
-    # Small delay to ensure processes are terminated
+
     sleep 1
 }
 
@@ -206,37 +252,56 @@ run_migrations() {
 
 # Start dev server
 start_dev_server() {
+    local dev_log=".next/e2e-dev-server.log"
+    mkdir -p .next
+
     if [ "$SERVER_MODE" = "prod" ]; then
         log_info "Building app (prod mode)..."
         npx dotenv -e .env.test -o -- npm run build
         log_success "Build complete"
 
         log_info "Starting production server on port $TEST_PORT..."
-        npx dotenv -e .env.test -o -- npm run start -- --port $TEST_PORT &
+        npx dotenv -e .env.test -o -- npm run start -- --port $TEST_PORT >>"$dev_log" 2>&1 &
         DEV_PID=$!
     else
-        log_info "Starting dev server on port $TEST_PORT..."
-    
-        # Start the dev server in background
-        npx dotenv -e .env.test -o -- npm run dev -- --port $TEST_PORT &
+        kill_port "$TEST_PORT"
+        if port_is_listening "$TEST_PORT"; then
+            log_error "Port $TEST_PORT is still in use after cleanup. Stop other dev servers and retry."
+            exit 1
+        fi
+
+        log_info "Starting dev server on port $TEST_PORT (logs: $dev_log)..."
+
+        # Use `next dev` directly so DEV_PID tracks the Node process (not a short-lived npm wrapper).
+        npx dotenv -e .env.test -o -- npx next dev --port "$TEST_PORT" >>"$dev_log" 2>&1 &
         DEV_PID=$!
     fi
-    
-    # Wait for server to be ready
+
     log_info "Waiting for dev server to be ready..."
     local retries=0
-    while [ $retries -lt 30 ]; do
-        if curl -s "http://localhost:$TEST_PORT/api/auth/session" >/dev/null 2>&1; then
+    while [ $retries -lt 60 ]; do
+        if ! kill -0 "$DEV_PID" 2>/dev/null; then
+            echo ""
+            log_error "Dev server process exited during startup (port $TEST_PORT may be in use)."
+            log_error "Last lines from $dev_log:"
+            tail -n 25 "$dev_log" >&2 || true
+            exit 1
+        fi
+
+        if curl -sf "http://localhost:$TEST_PORT/login" >/dev/null 2>&1; then
             log_success "Dev server is ready on port $TEST_PORT!"
             return 0
         fi
+
         retries=$((retries + 1))
         echo -n "."
         sleep 2
     done
-    
+
     echo ""
-    log_error "Dev server failed to start"
+    log_error "Dev server failed to respond within $((60 * 2))s"
+    log_error "Last lines from $dev_log:"
+    tail -n 25 "$dev_log" >&2 || true
     exit 1
 }
 
@@ -258,9 +323,10 @@ seed_database() {
 # Run Playwright tests
 run_tests() {
     log_info "Running E2E tests..."
-    
-    # Run Playwright with test environment
-    # Server is already running, so tell Playwright not to start its own
+    log_info "Auth setup runs first (11 users) — expect 1–2 minutes before specs start."
+
+    # Server is already running; skip Playwright webServer (avoids EADDRINUSE hang on Windows).
+    PLAYWRIGHT_MANAGED_SERVER=1 \
     PLAYWRIGHT_TEST_BASE_URL="http://localhost:$TEST_PORT" \
     npx dotenv -e .env.test -o -- npx playwright test --project=chromium "$@"
     

--- a/src/app/api/food-logs/[id]/route.ts
+++ b/src/app/api/food-logs/[id]/route.ts
@@ -18,6 +18,12 @@ function toNumber(value: string | number | null | undefined) {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+function roundToMealMinute(date: Date) {
+  const value = new Date(date);
+  value.setSeconds(0, 0);
+  return value;
+}
+
 // GET - Fetch a specific food log entry
 export async function GET(
   request: NextRequest,
@@ -237,15 +243,19 @@ export async function PATCH(
       .select({
         id: foodLogItems.id,
         mealId: foodLogItems.mealId,
+        mealType: foodLogMeals.mealType,
+        consumedAt: foodLogMeals.consumedAt,
       })
       .from(foodLogItems)
       .innerJoin(foodLogMeals, eq(foodLogItems.mealId, foodLogMeals.id))
       .where(and(eq(foodLogItems.id, logId), eq(foodLogMeals.userId, user.id)));
 
     if (existingItemLog.length > 0) {
+      const current = existingItemLog[0];
       const itemUpdateData: {
         quantity?: string;
         altMeasureId?: string | null;
+        mealId?: string;
         updatedAt?: Date;
       } = {};
 
@@ -256,34 +266,59 @@ export async function PATCH(
         itemUpdateData.altMeasureId = updateData.altMeasureId;
       }
 
+      if (updateData.mealType !== undefined || updateData.consumedAt !== undefined) {
+        const targetMealType = updateData.mealType ?? current.mealType;
+        const targetConsumedAt = updateData.consumedAt
+          ? roundToMealMinute(updateData.consumedAt)
+          : current.consumedAt;
+
+        const needsReassign =
+          targetMealType !== current.mealType ||
+          targetConsumedAt.getTime() !== current.consumedAt.getTime();
+
+        if (needsReassign) {
+          const existingTargetMeal = await db.query.foodLogMeals.findFirst({
+            where: and(
+              eq(foodLogMeals.userId, user.id),
+              eq(foodLogMeals.mealType, targetMealType),
+              eq(foodLogMeals.consumedAt, targetConsumedAt),
+            ),
+          });
+
+          let targetMealId = existingTargetMeal?.id;
+
+          if (!targetMealId) {
+            const [newMeal] = await db
+              .insert(foodLogMeals)
+              .values({
+                userId: user.id,
+                mealType: targetMealType,
+                consumedAt: targetConsumedAt,
+              })
+              .returning();
+            targetMealId = newMeal.id;
+          }
+
+          itemUpdateData.mealId = targetMealId;
+        }
+      }
+
       if (Object.keys(itemUpdateData).length > 0) {
         itemUpdateData.updatedAt = new Date();
+        const oldMealId = current.mealId;
         await db
           .update(foodLogItems)
           .set(itemUpdateData)
           .where(eq(foodLogItems.id, logId));
-      }
 
-      if (updateData.mealType !== undefined || updateData.consumedAt !== undefined) {
-        const mealUpdateData: {
-          mealType?: typeof foodLogMeals.$inferInsert.mealType;
-          consumedAt?: Date;
-          updatedAt?: Date;
-        } = {};
+        if (itemUpdateData.mealId && itemUpdateData.mealId !== oldMealId) {
+          const remainingInOldMeal = await db.query.foodLogItems.findFirst({
+            where: eq(foodLogItems.mealId, oldMealId),
+          });
 
-        if (updateData.mealType !== undefined) {
-          mealUpdateData.mealType = updateData.mealType;
-        }
-        if (updateData.consumedAt !== undefined) {
-          mealUpdateData.consumedAt = updateData.consumedAt;
-        }
-
-        if (Object.keys(mealUpdateData).length > 0) {
-          mealUpdateData.updatedAt = new Date();
-          await db
-            .update(foodLogMeals)
-            .set(mealUpdateData)
-            .where(eq(foodLogMeals.id, existingItemLog[0].mealId));
+          if (!remainingInOldMeal) {
+            await db.delete(foodLogMeals).where(eq(foodLogMeals.id, oldMealId));
+          }
         }
       }
 

--- a/src/components/landing/search-section.tsx
+++ b/src/components/landing/search-section.tsx
@@ -21,8 +21,9 @@ export function SearchSection() {
   const searchContainerRef = useRef<HTMLDivElement>(null);
 
   const handleSelect = (item: UnifiedFoodSearchResultItem) => {
-    if (item.fatSecretId) {
-      router.push(`/foods/${item.fatSecretId}`);
+    const detailId = item.fatSecretId ?? item.id;
+    if (detailId) {
+      router.push(`/foods/${detailId}`);
     }
   };
 


### PR DESCRIPTION
Improve Windows port cleanup in run-e2e, add shared search/plan helpers, reassign food-log items on PATCH when meal type or date changes, and fix landing search navigation for non-FatSecret foods.